### PR TITLE
fix: #601 - set data-sonner-toast to relative when descendant of popover-content

### DIFF
--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -124,3 +124,9 @@
 		</ScrollArea>
 	</Popover.Content>
 </Popover.Root>
+
+<style>
+   :global([data-slot="popover-content"] [data-sonner-toast]) {
+      position: relative;
+   }
+</style>


### PR DESCRIPTION
fixes #601 