### PR TITLE
feat(recording): allow users to select between native and browser recording backends

### DIFF
--- a/apps/whispering/src/lib/components/settings/README.md
+++ b/apps/whispering/src/lib/components/settings/README.md
@@ -7,7 +7,7 @@ This folder contains all components that are directly bound to the global settin
 Components in this directory:
 
 - Import and use the global `settings` store from `$lib/stores/settings.svelte`
-- Either take **no props** or only take a **`settingsKey` prop** to determine which setting to bind to
+- Either take **no props** or only take **minimal configuration props** (like `mode` or `settingsKey`) to determine which setting to bind to
 - Update settings directly using `settings.updateKey()` or `settings.update()` methods
 - Are self-contained and can be used globally throughout the application
 
@@ -16,7 +16,7 @@ Components in this directory:
 A component belongs here if it meets ALL of the following criteria:
 
 1. **Directly bound to settings**: The component imports and uses `settings` from `$lib/stores/settings.svelte`
-2. **Minimal props**: Takes either no props OR only a `settingsKey` prop (no value/onChange props)
+2. **Minimal props**: Takes either no props OR only minimal configuration props like `mode` or `settingsKey` (no value/onChange props)
 3. **Self-contained**: All state management is handled internally via the settings store
 4. **Reusable**: Can be dropped into any part of the app without additional setup
 
@@ -50,7 +50,7 @@ settings/
 <OpenAiApiKeyInput />
 ```
 
-### With Settings Key Prop
+### With Mode Prop
 
 ```svelte
 <script>
@@ -58,10 +58,10 @@ settings/
 </script>
 
 <!-- For VAD recording device -->
-<DeviceSelector settingsKey="vadRecorder.recordingDeviceId" />
+<DeviceSelector mode="vad" />
 
 <!-- For manual recording device -->
-<DeviceSelector settingsKey="manualRecorder.recordingDeviceId" />
+<DeviceSelector mode="manual" />
 ```
 
 ## Creating New Settings Components

--- a/apps/whispering/src/lib/query/settings.ts
+++ b/apps/whispering/src/lib/query/settings.ts
@@ -7,6 +7,7 @@ import { settings as settingsStore } from '$lib/stores/settings.svelte';
 import { nanoid } from 'nanoid/non-secure';
 import { Ok, type Result, partitionResults } from 'wellcrafted/result';
 import { defineMutation } from './_client';
+import { recorderService } from './recorder';
 
 /**
  * Centralized settings mutations that ensure consistent behavior across the application.
@@ -71,14 +72,14 @@ export const settings = {
  */
 async function stopAllRecordingModesExcept(modeToKeep: RecordingMode) {
 	const { data: currentRecordingId } =
-		await services.recorder.getCurrentRecordingId();
+		await recorderService().getCurrentRecordingId();
 	// Each recording mode with its check and stop logic
 	const recordingModes = [
 		{
 			mode: 'manual' as const,
 			isActive: () => currentRecordingId === 'RECORDING',
 			stop: () =>
-				services.recorder.stopRecording({
+				recorderService().stopRecording({
 					sendStatus: () => {}, // Silent cancel - no UI notifications
 				}),
 		},

--- a/apps/whispering/src/lib/services/index.ts
+++ b/apps/whispering/src/lib/services/index.ts
@@ -7,7 +7,7 @@ import { GlobalShortcutManagerLive } from './global-shortcut-manager';
 import { LocalShortcutManagerLive } from './local-shortcut-manager';
 import { NotificationServiceLive } from './notifications';
 import { OsServiceLive } from './os';
-import { RecorderServiceLive } from './recorder';
+import { NativeRecorderServiceLive, BrowserRecorderServiceLive } from './recorder';
 import { PlaySoundServiceLive } from './sound';
 import { ToastServiceLive } from './toast';
 import * as transcriptions from './transcription';
@@ -29,7 +29,8 @@ export {
 	GlobalShortcutManagerLive as globalShortcutManager,
 	LocalShortcutManagerLive as localShortcutManager,
 	NotificationServiceLive as notification,
-	RecorderServiceLive as recorder,
+	NativeRecorderServiceLive as nativeRecorder,
+	BrowserRecorderServiceLive as browserRecorder,
 	ToastServiceLive as toast,
 	OsServiceLive as os,
 	PlaySoundServiceLive as sound,

--- a/apps/whispering/src/lib/services/recorder/desktop.ts
+++ b/apps/whispering/src/lib/services/recorder/desktop.ts
@@ -325,5 +325,3 @@ async function invoke<T>(command: string, args?: Record<string, unknown>) {
 			Err({ name: 'TauriInvokeError', command, error } as const),
 	});
 }
-
-export const DesktopRecorderServiceLive = createDesktopRecorderService();

--- a/apps/whispering/src/lib/services/recorder/index.ts
+++ b/apps/whispering/src/lib/services/recorder/index.ts
@@ -2,12 +2,18 @@ import { createDesktopRecorderService } from './desktop';
 import { createWebRecorderService } from './web';
 
 /**
- * Platform-aware recorder service that automatically selects the appropriate implementation
- * based on whether we're running in Tauri (desktop) or browser (web)
+ * Native recorder service that uses the Rust backend when available.
+ * Falls back to browser recording when not in Tauri environment.
  */
-export const RecorderServiceLive = window.__TAURI_INTERNALS__
+export const NativeRecorderServiceLive = window.__TAURI_INTERNALS__
 	? createDesktopRecorderService()
 	: createWebRecorderService();
+
+/**
+ * Browser recorder service that always uses the MediaRecorder API,
+ * even when running in the desktop app.
+ */
+export const BrowserRecorderServiceLive = createWebRecorderService();
 
 // Re-export types for convenience
 export type { RecorderService, RecorderServiceError } from './types';

--- a/apps/whispering/src/lib/services/recorder/web.ts
+++ b/apps/whispering/src/lib/services/recorder/web.ts
@@ -223,5 +223,3 @@ export function createWebRecorderService(): RecorderService {
 		},
 	};
 }
-
-export const WebRecorderServiceLive = createWebRecorderService();

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -106,6 +106,12 @@ export const settingsSchema = z.object({
 	// Recording mode settings
 	'recording.mode': z.enum(RECORDING_MODES).default('manual'),
 	/**
+	 * Recording backend to use in desktop app.
+	 * - 'native': Uses Rust audio recording backend (CPAL)
+	 * - 'browser': Uses browser MediaRecorder API even in desktop
+	 */
+	'recording.backend': z.enum(['native', 'browser']).default('native'),
+	/**
 	 * Device identifier for manual recording.
 	 * Can be either a desktop device identifier or navigator device ID.
 	 * @see DeviceIdentifier
@@ -128,7 +134,7 @@ export const settingsSchema = z.object({
 		.transform((val) => (val ? asDeviceIdentifier(val) : null))
 		.default(null),
 
-	// Navigator settings (shared by manual, VAD, and live modes)
+	// Browser recording settings (used when browser backend is selected)
 	'recording.navigator.bitrateKbps': z
 		.enum(BITRATE_VALUES_KBPS)
 		.optional()

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -56,7 +56,7 @@
 				🚫
 			</WhisperingButton>
 		{:else}
-			<DeviceSelector strategy={window.__TAURI_INTERNALS__ ? 'cpal' : 'navigator'} />
+			<DeviceSelector mode="manual" />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
@@ -73,7 +73,7 @@
 		</WhisperingButton>
 	{:else if settings.value['recording.mode'] === 'vad'}
 		{#if getVadStateQuery.data === 'IDLE'}
-			<DeviceSelector strategy="navigator" />
+			<DeviceSelector mode="vad" />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
@@ -88,7 +88,7 @@
 		</WhisperingButton>
 	{:else if settings.value['recording.mode'] === 'live'}
 		{#if true}
-			<DeviceSelector strategy={window.__TAURI_INTERNALS__ ? 'cpal' : 'navigator'} />
+			<DeviceSelector mode="manual" />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}

--- a/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
@@ -15,6 +15,12 @@
 		{ value: '48000', label: 'High Quality (48kHz): Professional audio' },
 	] as const;
 
+	const RECORDING_BACKEND_OPTIONS = [
+		{ value: 'native', label: 'Native (Rust)' },
+		{ value: 'browser', label: 'Browser (MediaRecorder)' },
+	] as const;
+
+	const isUsingBrowserBackend = $derived(settings.value['recording.backend'] === 'browser');
 </script>
 
 <svelte:head>
@@ -44,13 +50,31 @@
 		).join(', ')}`}
 	/>
 
+	{#if window.__TAURI_INTERNALS__ && settings.value['recording.mode'] === 'manual'}
+		<LabeledSelect
+			id="recording-backend"
+			label="Recording Backend"
+			items={RECORDING_BACKEND_OPTIONS}
+			selected={settings.value['recording.backend']}
+			onSelectedChange={(selected) => {
+				settings.updateKey('recording.backend', selected);
+			}}
+			placeholder="Select a recording backend"
+			description={
+				settings.value['recording.backend'] === 'native'
+					? 'Native: Uses Rust audio backend for lower-level access and potentially better quality'
+					: 'Browser: Uses web standards (MediaRecorder API) for better compatibility'
+			}
+		/>
+	{/if}
+
 	{#if settings.value['recording.mode'] === 'manual'}
 		<SelectRecordingDevice
 			selected={settings.value['recording.manual.selectedDeviceId']}
 			onSelectedChange={(selected) => {
 				settings.updateKey('recording.manual.selectedDeviceId', selected);
 			}}
-			strategy={window.__TAURI_INTERNALS__ ? 'cpal' : 'navigator'}
+			mode="manual"
 		></SelectRecordingDevice>
 	{:else if settings.value['recording.mode'] === 'vad'}
 		<SelectRecordingDevice
@@ -58,14 +82,14 @@
 			onSelectedChange={(selected) => {
 				settings.updateKey('recording.vad.selectedDeviceId', selected);
 			}}
-			strategy="navigator"
+			mode="vad"
 		></SelectRecordingDevice>
 	{/if}
 
 	{#if settings.value['recording.mode'] === 'manual' || settings.value['recording.mode'] === 'vad'}
 
-		{#if !window.__TAURI_INTERNALS__}
-			<!-- Web-specific settings -->
+		{#if !window.__TAURI_INTERNALS__ || isUsingBrowserBackend}
+			<!-- Browser backend settings -->
 			<LabeledSelect
 				id="bit-rate"
 				label="Bitrate"
@@ -81,7 +105,7 @@
 				description="The bitrate of the recording. Higher values mean better quality but larger file sizes."
 			/>
 		{:else}
-			<!-- Desktop-specific settings -->
+			<!-- Native backend settings -->
 			<LabeledSelect
 				id="sample-rate"
 				label="Sample Rate"

--- a/apps/whispering/src/routes/(config)/settings/recording/SelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/SelectRecordingDevice.svelte
@@ -5,18 +5,28 @@
 	import type { DeviceIdentifier } from '$lib/services/types';
 	import { asDeviceIdentifier } from '$lib/services/types';
 
+	import { settings } from '$lib/stores/settings.svelte';
+	
 	let {
 		selected,
 		onSelectedChange,
-		strategy = 'cpal',
+		mode 
 	}: {
 		selected: DeviceIdentifier | null;
 		onSelectedChange: (selected: DeviceIdentifier | null) => void;
-		strategy?: 'cpal' | 'navigator';
+		mode: 'manual' | 'vad';
 	} = $props();
 
+	// Determine which backend to use for device enumeration
+	// VAD always uses browser, manual uses the configured backend
+	const isUsingBrowserBackend = $derived(
+		mode === 'vad' || 
+		!window.__TAURI_INTERNALS__ ||
+		settings.value['recording.backend'] === 'browser' 
+	);
+
 	const getDevicesQuery = createQuery(
-		strategy === 'navigator' 
+		isUsingBrowserBackend 
 			? rpc.vadRecorder.enumerateDevices.options
 			: rpc.recorder.enumerateDevices.options
 	);

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -275,7 +275,7 @@
 							🚫
 						</WhisperingButton>
 					{:else}
-						<DeviceSelector strategy={window.__TAURI_INTERNALS__ ? 'cpal' : 'navigator'} />
+						<DeviceSelector mode="manual" />
 						<TranscriptionSelector />
 						<TransformationSelector />
 					{/if}
@@ -300,7 +300,7 @@
 				<!-- Right column: Selectors -->
 				<div class="flex justify-end items-center gap-1.5 mb-2">
 					{#if getVadStateQuery.data === 'IDLE'}
-						<DeviceSelector strategy="navigator" />
+						<DeviceSelector mode="vad" />
 						<TranscriptionSelector />
 						<TransformationSelector />
 					{/if}


### PR DESCRIPTION
## Summary

This PR adds the ability for users to select between native (Rust/CPAL) and browser (MediaRecorder API) recording backends in the desktop app. This provides a workaround when users encounter issues with either backend.

## Changes

### New Recording Backend Setting
- Added `recording.backend` setting with options 'native' (default) and 'browser'
- Setting only appears in desktop app where both backends are available

### Service Architecture Updates
- Exported `NativeRecorderServiceLive` and `BrowserRecorderServiceLive` as separate static services
- Services maintain closure lifetimes as required
- Query layer dynamically selects appropriate service based on user preference

### Component API Simplification
- Refactored `DeviceSelector` component to use single `mode` prop ('manual' or 'vad')
- Removed redundant `strategy` prop - backend is now derived internally from:
  - Recording mode (VAD always uses browser)
  - User's backend preference setting
  - Environment (browser always uses browser backend)

### UI Improvements
- Added "Recording Backend" selector in recording settings (desktop only)
- Shows helpful descriptions for each backend option
- Device selector and recording settings update based on selected backend

## Benefits

1. **User Control**: Users can switch backends if they encounter device compatibility issues
2. **Cleaner API**: Single `mode` prop instead of both `mode` and `strategy`
3. **Better Debugging**: Easier to isolate backend-specific issues
4. **Flexibility**: Maintains all existing functionality while adding new options

## Testing

- [x] Native backend recording works correctly
- [x] Browser backend recording works in desktop app
- [x] Device selection saves properly for both backends
- [x] VAD mode continues to work (always uses browser backend)
- [x] Settings UI updates correctly based on backend selection