### PR TITLE
fix/settings-layout-shift

### DIFF
--- a/apps/whispering/src/routes/(config)/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/settings/+layout.svelte
@@ -36,7 +36,7 @@
 	})();
 </script>
 
-<main class="sm:container flex w-full flex-1 flex-col pb-4 pt-2 px-4 mx-auto">
+<main class="flex w-full flex-1 flex-col pb-4 pt-2 px-4 mx-auto max-w-6xl">
 	<div
 		class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
 	>


### PR DESCRIPTION
sm:container applies different max-widths at different
breakpoints, causing the "squeeze then center" effect
max-w-6xl applies a consistent 1152px max-width immediately, no

**Before** 
<img width="1277" height="800" alt="Screenshot 2025-08-16 at 1 18 20 AM" src="https://github.com/user-attachments/assets/f152d376-a34a-43bd-9676-47579a6c59a5" />

**After**
<img width="1277" height="800" alt="Screenshot 2025-08-16 at 1 18 04 AM" src="https://github.com/user-attachments/assets/038c964e-30ae-4192-81ca-4730933b4fa0" />
