### PR TITLE
show only desktop app link on website, hide in desktop

### DIFF
--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -416,7 +416,7 @@
 			{/if}
 			<p class="text-muted-foreground text-center text-sm font-light">
 				{#if !window.__TAURI_INTERNALS__}
-					Get Whispering for desktop from the 
+					Tired of switching tabs? 
 					<WhisperingButton
 						tooltipContent="Get Whispering for desktop"
 						href="https://epicenter.so/whispering"
@@ -425,7 +425,7 @@
 						variant="link"
 						size="inline"
 					>
-						app page
+						Get the native desktop app
 					</WhisperingButton>
 				{/if}
 			</p>

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -415,28 +415,19 @@
 				</p>
 			{/if}
 			<p class="text-muted-foreground text-center text-sm font-light">
-				Check out the {' '}<WhisperingButton
-					tooltipContent="Check out the Chrome Extension"
-					href="https://chromewebstore.google.com/detail/whispering/oilbfihknpdbpfkcncojikmooipnlglo"
-					target="_blank"
-					rel="noopener noreferrer"
-					variant="link"
-					size="inline"
-				>
-					extension
-				</WhisperingButton>{' '}
 				{#if !window.__TAURI_INTERNALS__}
-					and {' '}<WhisperingButton
-						tooltipContent="Check out the desktop app"
-						href="https://github.com/epicenter-so/epicenter/releases"
+					Get Whispering for desktop from the 
+					<WhisperingButton
+						tooltipContent="Get Whispering for desktop"
+						href="https://epicenter.so/whispering"
 						target="_blank"
 						rel="noopener noreferrer"
 						variant="link"
 						size="inline"
 					>
-						app
-					</WhisperingButton>{' '}
-				{/if} for more integrations!
+						app page
+					</WhisperingButton>
+				{/if}
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
**This PR updates the integration link behavior:**

- Desktop app (Tauri runtime): No integration links are shown.

- Website: Only the desktop app link is shown (removed the Chrome extension link).

- Tooltip: Updated to "Get Whispering for desktop" for clearer guidance.


**Changes**

- Removed conditional rendering of the Chrome extension link.

- Updated WhisperingButton tooltip content.

- Simplified logic: window.__TAURI_INTERNALS__ hides content in app; website only shows desktop app link.