### PR TITLE
Convert prettier config files to JS for auto-format from VS Code.

### DIFF
--- a/apps/api/prettier.config.js
+++ b/apps/api/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 import { prettierConfig } from '@repo/config/prettier';
 
 export default prettierConfig;

--- a/apps/posthog-reverse-proxy/prettier.config.js
+++ b/apps/posthog-reverse-proxy/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 import { prettierConfig } from '@repo/config/prettier';
 
 export default prettierConfig;

--- a/apps/sh/prettier.config.js
+++ b/apps/sh/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 import { prettierConfig } from '@repo/config/prettier';
 
 export default prettierConfig;

--- a/apps/whispering/prettier.config.js
+++ b/apps/whispering/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 import { prettierConfig } from '@repo/config/prettier';
 
 export default prettierConfig;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"exports": {
 		"./eslint": "./eslint.ts",
-		"./prettier": "./prettier.ts"
+		"./prettier": "./prettier.js"
 	},
 	"peerDependencies": {
 		"eslint": ">=9.0.0",

--- a/packages/config/prettier.js
+++ b/packages/config/prettier.js
@@ -1,5 +1,6 @@
-import type { Config } from 'prettier';
-import svelte from 'prettier-plugin-svelte';
+/**
+ * @typedef {import('prettier').Config} Config
+ */
 
 /**
  * Shared Prettier configuration for Svelte applications in the Whispering monorepo.
@@ -10,13 +11,15 @@ import svelte from 'prettier-plugin-svelte';
  * @remarks
  * While Biome handles general TypeScript/JavaScript formatting at the root level,
  * Svelte components require specialized formatting through the prettier-plugin-svelte.
+ *
+ * @type {Config}
  */
 export const prettierConfig = {
 	useTabs: true,
 	singleQuote: true,
 	trailingComma: 'all',
 	printWidth: 80,
-	plugins: [svelte],
+	plugins: ['prettier-plugin-svelte'],  // To avoid problems in VS Code, use string instead of imported object directly.
 	overrides: [
 		{
 			files: '*.svelte',
@@ -25,4 +28,4 @@ export const prettierConfig = {
 			},
 		},
 	],
-} satisfies Config;
+};

--- a/packages/ui/prettier.config.js
+++ b/packages/ui/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 import { prettierConfig } from '@repo/config/prettier';
 
 export default prettierConfig;


### PR DESCRIPTION
Currently prettier auto-formatting does not work in VS Code. This is because VS Code's internal version of node does not yet support TS (config) files.

- This PR converts the TS config files to JS files with JSDocs comments to maintain benefits of types.
- Additionally the 'prettier-plugin-svelte' package had to be passed to prettier as a string instead of import object due to other problems in VS Code.
- Confirmed `bun run format` continues to work.

**Auto-complete thanks to types still works:**
<img width="657" height="431" alt="image" src="https://github.com/user-attachments/assets/1b80f0d3-93ad-4dfa-9e7f-ff48b39f536d" />
