### PR TITLE
Feat/support xai and gsk keys

### DIFF
--- a/apps/whispering/src/lib/services/transcription/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/groq.ts
@@ -55,11 +55,11 @@ export function createGroqTranscriptionService() {
 				});
 			}
 
-			if (!options.apiKey.startsWith('gsk_')) {
+			if (!options.apiKey.startsWith('gsk') && !options.apiKey.startsWith('xai')) {
 				return WhisperingErr({
 					title: '🔑 Invalid API Key Format',
 					description:
-						'Your Groq API key should start with "gsk_". Please check and update your API key.',
+						'Your API key should start with "gsk" or "xai". Please check and update your API key.',
 					action: {
 						type: 'link',
 						label: 'Update API key',

--- a/apps/whispering/src/lib/services/transcription/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/groq.ts
@@ -55,11 +55,11 @@ export function createGroqTranscriptionService() {
 				});
 			}
 
-			if (!options.apiKey.startsWith('gsk') && !options.apiKey.startsWith('xai')) {
+			if (!options.apiKey.startsWith('gsk_') && !options.apiKey.startsWith('xai-')) {
 				return WhisperingErr({
 					title: '🔑 Invalid API Key Format',
 					description:
-						'Your API key should start with "gsk" or "xai". Please check and update your API key.',
+						'Your API key should start with "gsk_" or "xai-". Please check and update your API key.',
 					action: {
 						type: 'link',
 						label: 'Update API key',

--- a/apps/whispering/src/lib/services/transcription/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/groq.ts
@@ -59,7 +59,7 @@ export function createGroqTranscriptionService() {
 				return WhisperingErr({
 					title: '🔑 Invalid API Key Format',
 					description:
-						'Your API key should start with "gsk_" or "xai-". Please check and update your API key.',
+						'Your Groq API key should start with "gsk_" or "xai-". Please check and update your API key.',
 					action: {
 						type: 'link',
 						label: 'Update API key',


### PR DESCRIPTION
PR #681 
- Allows users to use either legacy gsk_ keys or new xai- keys.
- Updates validation and error messages accordingly.