### PR TITLE
fix(whispering): ensure notifications button has classes applied.

### DIFF
--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -45,12 +45,16 @@
 <Popover.Root bind:open={notificationLog.isOpen}>
 	<Popover.Trigger>
 		{#snippet child({ props })}
+			{@const { class: propsClass, ...restProps } = props}
 			<WhisperingButton
 				tooltipContent="Notification History"
-				class="fixed bottom-4 right-4 z-50 hidden xs:inline-flex"
+				class={cn(
+					'fixed bottom-4 right-4 z-50 hidden xs:inline-flex',
+					propsClass,
+				)}
 				variant="outline"
 				size="icon"
-				{...props}
+				{...restProps}
 			>
 				<LogsIcon class="size-4" />
 			</WhisperingButton>


### PR DESCRIPTION
- Before this change, the `class` defined here (in the snippet) was being overwritten by the props being passed in.
- This ensures the button truly has fixed positioning as intended by the classes.
- **Note:** the `right-4` is also honored now, moving the button from the left to right corner. (The button will be covered by any toasts, making it inaccessible.)
- **Note:** the `z-50` is also honored, making the button appear above the modal overlay; however this is only visual. (Clicking the button will not activate the notifications log.)
- This PR fixes the same bug as: https://github.com/epicenter-so/epicenter/pull/673

# Before

**Notifications button is not hidden at xxs breakpoint.**
<img width="74" height="86" alt="image" src="https://github.com/user-attachments/assets/60786c60-3ee4-4d0e-89a6-4b0b3967f00b" />

**Notifications button is not fixed; must scroll to bottom to find**
<img width="1082" height="802" alt="image" src="https://github.com/user-attachments/assets/e9b7f09f-7c8e-4a1d-8178-40138868c56c" />


# After
**All classes honored, now: `fixed bottom-4 right-4 z-50 hidden xs:inline-flex`**
<img width="74" height="86" alt="image" src="https://github.com/user-attachments/assets/b5023157-2c52-4da9-801c-8505ff2b3838" />

<img width="1082" height="802" alt="image" src="https://github.com/user-attachments/assets/287cd01a-e270-40c2-8047-90212e111088" />
