### PR TITLE
Add active state highlighting to navigation items

### DIFF
--- a/apps/whispering/src/lib/components/NavItems.svelte
+++ b/apps/whispering/src/lib/components/NavItems.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import { GithubIcon } from '$lib/components/icons';
 	import * as DropdownMenu from '@repo/ui/dropdown-menu';
@@ -38,6 +39,7 @@
 			icon: SettingsIcon,
 			type: 'anchor',
 			href: '/settings',
+			activePathPrefix: '/settings',
 		},
 		{
 			label: 'View project on GitHub',
@@ -73,6 +75,7 @@
 		type: 'anchor';
 		href: string;
 		external?: boolean;
+		activePathPrefix?: string;
 	};
 
 	type ButtonItem = BaseNavItem & {
@@ -86,6 +89,14 @@
 	};
 
 	type NavItem = AnchorItem | ButtonItem | ThemeItem;
+
+	const isItemActive = (item: AnchorItem) => {
+		if (item.external) return false;
+		if (item.activePathPrefix) {
+			return page.url.pathname.startsWith(item.activePathPrefix);
+		}
+		return page.url.pathname === item.href;
+	};
 </script>
 
 {#if collapsed}
@@ -107,13 +118,17 @@
 			{#each navItems as item}
 				{@const Icon = item.icon}
 				{#if item.type === 'anchor'}
+					{@const isActive = isItemActive(item)}
 					<DropdownMenu.Item>
 						{#snippet child({ props })}
 							<a
 								href={item.href}
 								target={item.external ? '_blank' : undefined}
 								rel={item.external ? 'noopener noreferrer' : undefined}
-								class="flex items-center gap-2"
+								class={cn(
+									'flex items-center gap-2',
+									isActive && 'bg-accent text-accent-foreground',
+								)}
 								{...props}
 							>
 								<Icon class="size-4" aria-hidden="true" />
@@ -156,13 +171,15 @@
 		{#each navItems as item}
 			{@const Icon = item.icon}
 			{#if item.type === 'anchor'}
+				{@const isActive = isItemActive(item)}
 				<WhisperingButton
 					tooltipContent={item.label}
 					href={item.href}
 					target={item.external ? '_blank' : undefined}
 					rel={item.external ? 'noopener noreferrer' : undefined}
-					variant="ghost"
+					variant={isActive ? 'secondary' : 'ghost'}
 					size="icon"
+					class={isActive ? 'ring-2 ring-ring/20' : ''}
 				>
 					<Icon class="size-4" aria-hidden="true" />
 				</WhisperingButton>


### PR DESCRIPTION
**This PR marks the start of improving navigation overall in the codebase** 

- Right now, our navigation is kind of all over the place and has some issues with UX flow, see example ->  #710
- It's not that we have bad navigation, but it feels a bit unintuitive
- This PR highlights navigation items making it easier for the user to know where they currently are

> Before

<img width="369" height="75" alt="Screenshot 2025-08-25 at 10 57 15 PM" src="https://github.com/user-attachments/assets/c5099575-51a9-477a-98c8-494116e2026a" />

> After

<img width="369" height="76" alt="Screenshot 2025-08-25 at 10 56 08 PM" src="https://github.com/user-attachments/assets/b1522c0c-d5e1-45f0-87e6-f6d7a15153b6" />

---

<img width="359" height="50" alt="Screenshot 2025-08-25 at 10 56 53 PM" src="https://github.com/user-attachments/assets/25e9be84-5db5-46e4-82b5-7e12766e6ff3" />



