### PR TITLE
refactor(settings): replace resetShortcuts switch with dedicated methods

### DIFF
--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -63,10 +63,13 @@ export const settings = (() => {
 	});
 
 	// Private helper for shared reset logic
-	function resetShortcutDefaults(type: 'local' | 'global') {
+	function _resetShortcutDefaults(type: 'local' | 'global') {
 		const defaultSettings = getDefaultSettings();
+
+		// Build a partial settings object containing only the shortcuts we want to reset
 		const updates = commands.reduce<Partial<Settings>>((acc, command) => {
 			const shortcutKey = `shortcuts.${type}.${command.id}` as const;
+			// Copy the default value for this specific shortcut from defaultSettings to our updates object
 			acc[shortcutKey] = defaultSettings[shortcutKey];
 			return acc;
 		}, {});
@@ -113,7 +116,7 @@ export const settings = (() => {
 		 * Reset local shortcuts to their default values
 		 */
 		resetLocalShortcuts() {
-			resetShortcutDefaults('local');
+			_resetShortcutDefaults('local');
 			syncLocalShortcutsWithSettings();
 		},
 
@@ -121,7 +124,7 @@ export const settings = (() => {
 		 * Reset global shortcuts to their default values
 		 */
 		resetGlobalShortcuts() {
-			resetShortcutDefaults('global');
+			_resetShortcutDefaults('global');
 			syncGlobalShortcutsWithSettings();
 		},
 	};

--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -62,6 +62,21 @@ export const settings = (() => {
 		},
 	});
 
+	// Private helper for shared reset logic
+	function resetShortcutDefaults(type: 'local' | 'global') {
+		const defaultSettings = getDefaultSettings();
+		const updates = commands.reduce<Partial<Settings>>((acc, command) => {
+			const shortcutKey = `shortcuts.${type}.${command.id}` as const;
+			acc[shortcutKey] = defaultSettings[shortcutKey];
+			return acc;
+		}, {});
+
+		_settings.value = {
+			..._settings.value,
+			...updates,
+		};
+	}
+
 	return {
 		/**
 		 * Read-only access to current settings values
@@ -95,30 +110,19 @@ export const settings = (() => {
 		},
 
 		/**
-		 * Reset shortcuts to their default values
-		 * @param type 'local' or 'global' shortcuts to reset
+		 * Reset local shortcuts to their default values
 		 */
-		resetShortcuts(type: 'local' | 'global') {
-			const defaultSettings = getDefaultSettings();
-			const updates = commands.reduce<Partial<Settings>>((acc, command) => {
-				const shortcutKey = `shortcuts.${type}.${command.id}` as const;
-				acc[shortcutKey] = defaultSettings[shortcutKey];
-				return acc;
-			}, {});
+		resetLocalShortcuts() {
+			resetShortcutDefaults('local');
+			syncLocalShortcutsWithSettings();
+		},
 
-			_settings.value = {
-				..._settings.value,
-				...updates,
-			};
-
-			switch (type) {
-				case 'local':
-					syncLocalShortcutsWithSettings();
-					break;
-				case 'global':
-					syncGlobalShortcutsWithSettings();
-					break;
-			}
+		/**
+		 * Reset global shortcuts to their default values
+		 */
+		resetGlobalShortcuts() {
+			resetShortcutDefaults('global');
+			syncGlobalShortcutsWithSettings();
 		},
 	};
 })();

--- a/apps/whispering/src/routes/+layout/register-commands.ts
+++ b/apps/whispering/src/routes/+layout/register-commands.ts
@@ -86,7 +86,7 @@ export function resetLocalShortcutsToDefaultIfDuplicates(): boolean {
 		if (shortcut) {
 			if (localShortcuts.has(shortcut)) {
 				// If duplicates found, reset all local shortcuts to defaults
-				settings.resetShortcuts('local');
+				settings.resetLocalShortcuts();
 				rpc.notify.success.execute({
 					title: 'Shortcuts reset',
 					description:
@@ -119,7 +119,7 @@ export function resetGlobalShortcutsToDefaultIfDuplicates(): boolean {
 		if (shortcut) {
 			if (globalShortcuts.has(shortcut)) {
 				// If duplicates found, reset all global shortcuts to defaults
-				settings.resetShortcuts('global');
+				settings.resetGlobalShortcuts();
 				rpc.notify.success.execute({
 					title: 'Shortcuts reset',
 					description:


### PR DESCRIPTION
Replace single resetShortcuts(type) method with dedicated resetLocalShortcuts() and resetGlobalShortcuts() methods. Eliminates switch statement and provides cleaner abstraction with method-specific behavior.