### PR TITLE
feat(transcription): add audio compression before transcription

### DIFF
--- a/apps/whispering/src/lib/constants/transcription/transcription-services.ts
+++ b/apps/whispering/src/lib/constants/transcription/transcription-services.ts
@@ -40,7 +40,7 @@ export const TRANSCRIPTION_SERVICE_IDS = [
 	// 'owhisper',
 ] as const;
 
-type TranscriptionServiceId = (typeof TRANSCRIPTION_SERVICE_IDS)[number];
+export type TranscriptionServiceId = (typeof TRANSCRIPTION_SERVICE_IDS)[number];
 
 type BaseTranscriptionService = {
 	id: TranscriptionServiceId;

--- a/apps/whispering/src/lib/services/analytics/types.ts
+++ b/apps/whispering/src/lib/services/analytics/types.ts
@@ -45,6 +45,19 @@ export type Event =
 			error_title: string;
 			error_description?: string;
 	  }
+	// Compression events
+	| {
+			type: 'compression_completed';
+			provider: TranscriptionServiceId;
+			original_size: number;
+			compressed_size: number;
+			compression_ratio: number;
+	  }
+	| {
+			type: 'compression_failed';
+			provider: TranscriptionServiceId;
+			error_message: string;
+	  }
 	// Settings events
 	| { type: 'settings_changed'; section: SettingsSection };
 

--- a/apps/whispering/src/lib/services/ffmpeg/desktop.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/desktop.ts
@@ -2,6 +2,15 @@ import { IS_WINDOWS } from '$lib/constants/platform';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import { type FfmpegService, FfmpegServiceErr } from './types';
+import { writeFile, remove, exists } from '@tauri-apps/plugin-fs';
+import { appDataDir, join } from '@tauri-apps/api/path';
+import { nanoid } from 'nanoid/non-secure';
+import * as services from '$lib/services';
+import {
+	buildCompressionCommand,
+	getFileExtensionFromFfmpegOptions,
+} from '../recorder/ffmpeg';
+import { asShellCommand } from '../command/types';
 
 export function createFfmpegService(): FfmpegService {
 	return {
@@ -25,6 +34,91 @@ export function createFfmpegService(): FfmpegService {
 
 			if (shellFfmpegError) return Err(shellFfmpegError);
 			return Ok(shellFfmpegProcess.code === 0);
+		},
+
+		async compressAudioBlob(blob: Blob, compressionOptions: string) {
+			return await tryAsync({
+				try: async () => {
+					// Generate unique filenames for temporary files
+					const sessionId = nanoid();
+					const tempDir = await appDataDir();
+					const inputPath = await join(
+						tempDir,
+						`compression_input_${sessionId}.wav`,
+					);
+
+					// Determine output extension and path based on compression options
+					const outputExtension =
+						getFileExtensionFromFfmpegOptions(compressionOptions);
+					const outputPath = await join(
+						tempDir,
+						`compression_output_${sessionId}.${outputExtension}`,
+					);
+
+					try {
+						// Write input blob to temporary file
+						const inputContents = new Uint8Array(await blob.arrayBuffer());
+						await writeFile(inputPath, inputContents);
+
+						// Build FFmpeg command for compression using the utility function
+						const { command } = buildCompressionCommand({
+							inputPath,
+							compressionOptions,
+							outputPath,
+						});
+
+						// Execute FFmpeg compression command
+						const { data: result, error: commandError } =
+							await services.command.execute(asShellCommand(command));
+						if (commandError) {
+							throw new Error(
+								`FFmpeg compression failed: ${commandError.message}`,
+							);
+						}
+
+						// Check if FFmpeg command was successful
+						if (result.code !== 0) {
+							throw new Error(
+								`FFmpeg compression failed with exit code ${result.code}: ${result.stderr}`,
+							);
+						}
+
+						// Verify output file exists
+						const outputExists = await exists(outputPath);
+						if (!outputExists) {
+							throw new Error(
+								'FFmpeg compression completed but output file was not created',
+							);
+						}
+
+						// Read compressed file back as blob
+						const { data: compressedBlob, error: readError } =
+							await services.fs.pathToBlob(outputPath);
+						if (readError) {
+							throw new Error(
+								`Failed to read compressed audio file: ${readError.message}`,
+							);
+						}
+
+						return compressedBlob;
+					} finally {
+						// Clean up temporary files
+						await tryAsync({
+							try: async () => {
+								if (await exists(inputPath)) await remove(inputPath);
+								if (await exists(outputPath)) await remove(outputPath);
+							},
+							catch: () => Ok(undefined), // Ignore cleanup errors
+						});
+					}
+				},
+				catch: (error) =>
+					FfmpegServiceErr({
+						message: `Audio compression failed: ${extractErrorMessage(error)}`,
+						context: { compressionOptions },
+						cause: error,
+					}),
+			});
 		},
 	};
 }

--- a/apps/whispering/src/lib/services/ffmpeg/types.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/types.ts
@@ -1,9 +1,10 @@
 import { createTaggedError } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
+
 export const { FfmpegServiceErr, FfmpegServiceError } =
 	createTaggedError('FfmpegServiceError');
 
-type FfmpegServiceError = ReturnType<typeof FfmpegServiceError>;
+export type FfmpegServiceError = ReturnType<typeof FfmpegServiceError>;
 
 export type FfmpegService = {
 	/**
@@ -11,4 +12,17 @@ export type FfmpegService = {
 	 * Returns Ok(true) if installed, Ok(false) if not installed.
 	 */
 	checkInstalled(): Promise<Result<boolean, FfmpegServiceError>>;
+
+	/**
+	 * Compresses an audio blob using FFmpeg with the specified compression options.
+	 * Creates temporary files for processing and returns a compressed audio blob.
+	 *
+	 * @param blob - The input audio blob to compress
+	 * @param compressionOptions - FFmpeg compression options (e.g., "-c:a libopus -b:a 32k -ar 16000 -ac 1")
+	 * @returns A Result containing the compressed blob or an error
+	 */
+	compressAudioBlob(
+		blob: Blob,
+		compressionOptions: string,
+	): Promise<Result<Blob, FfmpegServiceError>>;
 };

--- a/apps/whispering/src/lib/services/ffmpeg/web.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/web.ts
@@ -1,12 +1,22 @@
-import { Ok, type Result } from 'wellcrafted/result';
-import type { WhisperingError } from '$lib/result';
+import { Ok } from 'wellcrafted/result';
 import type { FfmpegService } from './types';
+import { FfmpegServiceErr } from './types';
 
 export function createFfmpegServiceWeb(): FfmpegService {
 	return {
-		async checkInstalled(): Promise<Result<boolean, WhisperingError>> {
+		async checkInstalled() {
 			// FFmpeg check is not available in web version, assume not installed
 			return Ok(false);
+		},
+
+		async compressAudioBlob(_blob: Blob, compressionOptions: string) {
+			// Audio compression is not available in web version
+			return FfmpegServiceErr({
+				message:
+					'Audio compression is not available in the web version. FFmpeg is only supported in the desktop application.',
+				context: { compressionOptions },
+				cause: undefined,
+			});
 		},
 	};
 }

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -48,6 +48,7 @@ import {
 	FFMPEG_DEFAULT_GLOBAL_OPTIONS,
 	FFMPEG_DEFAULT_INPUT_OPTIONS,
 	FFMPEG_DEFAULT_OUTPUT_OPTIONS,
+	FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
 } from '$lib/services/recorder/ffmpeg';
 import { type ZodBoolean, type ZodString, z } from 'zod';
 import type { DeepgramModel } from '$lib/services/transcription/deepgram';
@@ -170,6 +171,12 @@ export const settingsSchema = z.object({
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
 	'transcription.temperature': z.string().default('0.0'),
+	
+	// Audio compression settings
+	'transcription.compressionEnabled': z.boolean().default(false),
+	'transcription.compressionOptions': z
+		.string()
+		.default(FFMPEG_DEFAULT_COMPRESSION_OPTIONS),
 
 	// Service-specific settings
 	'transcription.openai.model': z

--- a/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
@@ -13,7 +13,7 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import SelectRecordingDevice from './SelectRecordingDevice.svelte';
 	import {
-		isUsingCpalMethodWithCloudTranscription,
+		isUsingCpalMethodWithoutWhisperCpp,
 		isUsingCpalMethodAtWrongSampleRate,
 	} from '../../../+layout/check-ffmpeg';
 	import { IS_MACOS, IS_LINUX, PLATFORM_TYPE } from '$lib/constants/platform';
@@ -168,7 +168,7 @@
 					</Link>
 				</Alert.Description>
 			</Alert.Root>
-		{:else if isUsingCpalMethodWithCloudTranscription() && !data.ffmpegInstalled}
+		{:else if isUsingCpalMethodWithoutWhisperCpp() && !data.ffmpegInstalled}
 			<Alert.Root class="border-amber-500/20 bg-amber-500/5">
 				<InfoIcon class="size-4 text-amber-600 dark:text-amber-400" />
 				<Alert.Title class="text-amber-600 dark:text-amber-400">

--- a/apps/whispering/src/routes/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -15,6 +15,7 @@
 	import {
 		buildFfmpegCommand,
 		formatDeviceForPlatform,
+		getFileExtensionFromFfmpegOptions,
 		FFMPEG_DEFAULT_DEVICE_IDENTIFIER,
 		FFMPEG_DEFAULT_GLOBAL_OPTIONS,
 		FFMPEG_DEFAULT_INPUT_OPTIONS,
@@ -93,14 +94,7 @@
 		bitrate: string;
 		quality: string;
 	} {
-		const format = (() => {
-			if (options?.includes('libmp3lame')) return 'mp3';
-			if (options?.includes('aac')) return 'aac';
-			if (options?.includes('libvorbis')) return 'ogg';
-			if (options?.includes('libopus')) return 'opus';
-			if (options?.includes('pcm_s16le')) return 'wav';
-			return 'wav'; // Default to WAV for maximum compatibility
-		})();
+		const format = getFileExtensionFromFfmpegOptions(options);
 
 		const sampleRate = options?.match(/-ar\s+(\d+)/)?.[1] ?? '16000';
 		const bitrate = options?.match(/-b:a\s+(\d+)k?/)?.[1] ?? '128';

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -42,6 +42,7 @@
 	import {
 		isUsingWhisperCppWithBrowserMethod,
 		isUsingCpalMethodAtWrongSampleRate,
+		isUsingCpalMethodWithoutWhisperCpp,
 	} from '../../../+layout/check-ffmpeg';
 	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
 	import { cn } from '@repo/ui/utils';
@@ -452,17 +453,29 @@
 	{/if}
 
 	<!-- Audio Compression Settings -->
-	<div class="flex items-center space-x-2">
-		<Checkbox
-			id="compression-enabled"
-			checked={settings.value['transcription.compressionEnabled']}
-			onCheckedChange={(checked) => {
-				settings.updateKey('transcription.compressionEnabled', checked);
-			}}
-		/>
-		<label for="compression-enabled" class="text-sm font-medium">
-			Compress audio before transcription
-		</label>
+	<div class="space-y-2">
+		<div class="flex items-center space-x-2">
+			<Checkbox
+				id="compression-enabled"
+				checked={settings.value['transcription.compressionEnabled']}
+				onCheckedChange={(checked) => {
+					settings.updateKey('transcription.compressionEnabled', checked);
+				}}
+			/>
+			<label for="compression-enabled" class="text-sm font-medium">
+				Compress audio before transcription
+				{#if isUsingCpalMethodWithoutWhisperCpp()}
+					<Badge variant="secondary" class="ml-2">Recommended</Badge>
+				{/if}
+			</label>
+		</div>
+		{#if isUsingCpalMethodWithoutWhisperCpp()}
+			<p class="text-muted-foreground text-sm ml-6">
+				Recommended because you're using CPAL recording with cloud
+				transcription. Compression reduces file sizes for faster uploads and
+				lower API costs.
+			</p>
+		{/if}
 	</div>
 
 	{#if settings.value['transcription.compressionEnabled']}

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -31,12 +31,67 @@
 		DEEPGRAM_TRANSCRIPTION_MODELS,
 	} from '$lib/constants/transcription';
 	import { settings } from '$lib/stores/settings.svelte';
-	import { TriangleAlert, InfoIcon, CheckIcon } from '@lucide/svelte';
+	import {
+		TriangleAlert,
+		InfoIcon,
+		CheckIcon,
+		RotateCcw,
+	} from '@lucide/svelte';
 	import WhisperModelSelector from '$lib/components/settings/WhisperModelSelector.svelte';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import {
 		isUsingWhisperCppWithBrowserMethod,
 		isUsingCpalMethodAtWrongSampleRate,
 	} from '../../../+layout/check-ffmpeg';
+	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
+	import { cn } from '@repo/ui/utils';
+
+	// Compression preset definitions (UI only - not stored in settings)
+	const COMPRESSION_PRESETS = {
+		recommended: {
+			label: 'Recommended',
+			icon: '🎯',
+			description: 'Best balance for speech',
+			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
+			size: '~240KB/min',
+		},
+		tiny: {
+			label: 'Smallest',
+			icon: '🗜️',
+			description: 'Maximum compression',
+			options: '-c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+			size: '~120KB/min',
+		},
+		compatible: {
+			label: 'Compatible',
+			icon: '✅',
+			description: 'Universal MP3',
+			options: '-c:a libmp3lame -b:a 32k -ar 16000 -ac 1 -q:a 9',
+			size: '~240KB/min',
+		},
+		quality: {
+			label: 'High Quality',
+			icon: '🎵',
+			description: 'Less compression',
+			options: '-c:a libmp3lame -b:a 64k -ar 16000 -ac 1 -q:a 2',
+			size: '~480KB/min',
+		},
+	} as const;
+
+	// Derive which preset is active based on current options
+	function isPresetActive(
+		presetKey: keyof typeof COMPRESSION_PRESETS,
+	): boolean {
+		return (
+			settings.value['transcription.compressionOptions'] ===
+			COMPRESSION_PRESETS[presetKey].options
+		);
+	}
+
+	// Set compression options directly
+	function setCompressionOptions(options: string) {
+		settings.updateKey('transcription.compressionOptions', options);
+	}
 </script>
 
 <svelte:head>
@@ -369,8 +424,8 @@
 					</Alert.Title>
 					<Alert.Description>
 						Whisper C++ requires 16kHz audio. FFmpeg is needed to convert from
-						your current {settings.value['recording.cpal.sampleRate']}Hz
-						sample rate.
+						your current {settings.value['recording.cpal.sampleRate']}Hz sample
+						rate.
 						<Link
 							href="/install-ffmpeg"
 							class="font-medium underline underline-offset-4 hover:text-amber-700 dark:hover:text-amber-300"
@@ -393,6 +448,92 @@
 			<label for="whispercpp-use-gpu" class="text-sm font-medium">
 				Use GPU acceleration (if available)
 			</label>
+		</div>
+	{/if}
+
+	<!-- Audio Compression Settings -->
+	<div class="flex items-center space-x-2">
+		<Checkbox
+			id="compression-enabled"
+			checked={settings.value['transcription.compressionEnabled']}
+			onCheckedChange={(checked) => {
+				settings.updateKey('transcription.compressionEnabled', checked);
+			}}
+		/>
+		<label for="compression-enabled" class="text-sm font-medium">
+			Compress audio before transcription
+		</label>
+	</div>
+
+	{#if settings.value['transcription.compressionEnabled']}
+		<div class="space-y-4">
+			<!-- Preset Selection Badges -->
+			<div class="space-y-2">
+				<p class="text-sm font-medium">Compression Presets</p>
+				<div class="flex flex-wrap gap-2">
+					{#each Object.entries(COMPRESSION_PRESETS) as [presetKey, preset]}
+						<Badge
+							variant={isPresetActive(presetKey) ? 'default' : 'outline'}
+							class={cn(
+								'cursor-pointer transition-colors',
+								isPresetActive(presetKey)
+									? 'hover:bg-primary/90'
+									: 'hover:bg-accent hover:text-accent-foreground',
+							)}
+							onclick={() => setCompressionOptions(preset.options)}
+						>
+							<span class="mr-1">{preset.icon}</span>
+							{preset.label}
+							<span class="text-xs ml-1 opacity-75">{preset.size}</span>
+						</Badge>
+					{/each}
+				</div>
+				<p class="text-muted-foreground text-xs">
+					Choose a preset to automatically set FFmpeg compression options, or
+					customize below.
+				</p>
+			</div>
+
+			<!-- Custom Options Input -->
+			<LabeledInput
+				id="compression-options"
+				label="Compression Options"
+				value={settings.value['transcription.compressionOptions']}
+				oninput={({ currentTarget: { value } }) => {
+					settings.updateKey('transcription.compressionOptions', value);
+				}}
+				placeholder={FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
+				description="FFmpeg compression options. Changes here will be reflected in real-time during transcription."
+			>
+				{#snippet actionSlot()}
+					{#if settings.value['transcription.compressionOptions'] !== FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
+						<WhisperingButton
+							tooltipContent="Reset to default"
+							variant="ghost"
+							size="icon"
+							class="h-6 w-6"
+							onclick={() => {
+								settings.updateKey(
+									'transcription.compressionOptions',
+									FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
+								);
+							}}
+						>
+							<RotateCcw class="h-3 w-3" />
+						</WhisperingButton>
+					{/if}
+				{/snippet}
+			</LabeledInput>
+
+			<!-- Command Preview -->
+			<div class="text-sm text-muted-foreground">
+				<p class="font-medium mb-1">Command Preview:</p>
+				<code class="bg-muted rounded px-2 py-1 text-xs break-all">
+					ffmpeg -i input.wav {settings.value[
+						'transcription.compressionOptions'
+					]} output.opus
+				</code>
+			</div>
 		</div>
 	{/if}
 

--- a/apps/whispering/src/routes/+layout/check-ffmpeg.ts
+++ b/apps/whispering/src/routes/+layout/check-ffmpeg.ts
@@ -64,7 +64,7 @@ export function isUsingCpalMethodAtWrongSampleRate(): boolean {
  * Only relevant when using CPAL method with cloud providers (not Whisper C++)
  * @returns true if using CPAL method with any cloud transcription service
  */
-export function isUsingCpalMethodWithCloudTranscription(): boolean {
+export function isUsingCpalMethodWithoutWhisperCpp(): boolean {
 	return isUsingCpalMethod() && !isUsingWhisperCpp();
 }
 
@@ -100,30 +100,7 @@ export async function checkFfmpeg() {
 	const { data: ffmpegInstalled } =
 		await rpc.ffmpeg.checkFfmpegInstalled.ensure();
 
-	// FFmpeg is installed - check if we should suggest compression
-	if (ffmpegInstalled === true) {
-		const shouldSuggestCompression =
-			isUsingCloudTranscription() &&
-			!settings.value['transcription.compressionEnabled'];
-		if (shouldSuggestCompression) {
-			toast.info('Enable Compression to Save on API Costs', {
-				description:
-					'FFmpeg is installed! Enable audio compression to reduce file sizes and save on transcription costs.',
-				action: {
-					label: 'Enable Compression',
-					onClick: () => {
-						settings.updateKey('transcription.compressionEnabled', true);
-						toast.success(
-							'Compression enabled! Your audio will now be compressed before transcription.',
-						);
-					},
-				},
-				duration: 12000,
-			});
-		}
-
-		return; // FFmpeg is installed, all good
-	}
+	if (ffmpegInstalled === true) return; // FFmpeg is installed, all good
 
 	// Case 1: Whisper C++ with browser method - always requires FFmpeg
 	if (isUsingWhisperCppWithBrowserMethod()) {
@@ -154,7 +131,7 @@ export async function checkFfmpeg() {
 	}
 
 	// Case 3: CPAL method with cloud services - recommended for compression
-	if (isUsingCpalMethodWithCloudTranscription()) {
+	if (isUsingCpalMethodWithoutWhisperCpp()) {
 		toast.info('Install FFmpeg for Enhanced Audio Support', {
 			description:
 				'FFmpeg enables audio compression for faster uploads to transcription services.',


### PR DESCRIPTION
This adds optional audio compression before transcription to reduce file sizes and API costs while maintaining transcription quality. Users can compress audio using FFmpeg before sending to transcription services, with comprehensive preset options and custom configuration support.

The implementation integrates seamlessly into the existing transcription workflow with automatic fallback to original audio if compression fails. Compression typically reduces file sizes by ~6x (e.g., 1.5MB WAV to 240KB Opus) while preserving speech quality for accurate transcription.

The feature includes four compression presets optimized for different use cases: Recommended (Opus 32kbps), Smallest (Opus 16kbps), Compatible (MP3), and High Quality (MP3 64kbps). Users can also specify custom FFmpeg compression options with live command preview.

Compression is desktop-only since it requires FFmpeg. The web version gracefully handles this limitation with appropriate error messaging. Analytics tracking captures compression success/failure rates and size reduction metrics.

Key technical details: the compression uses temporary files for processing, with automatic cleanup on completion or failure. The system validates FFmpeg installation and provides clear feedback when compression fails, ensuring the transcription process continues uninterrupted with the original audio.

<img width="1658" height="1370" alt="CleanShot 2025-09-02 at 12 01 14@2x" src="https://github.com/user-attachments/assets/46dc4bbe-893c-4adb-b0d3-8b513dad64d2" />
