### PR TITLE
refactor: simplify device selection architecture

### DIFF
--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -39,12 +39,6 @@
 			description: 'Universal compatibility',
 			options: '-c:a libmp3lame -b:a 32k -ar 16000 -ac 1 -q:a 9',
 		},
-		quality: {
-			label: 'High Quality',
-			icon: '🎵',
-			description: 'Less compression, keep everything',
-			options: '-c:a libmp3lame -b:a 64k -ar 16000 -ac 1 -q:a 2',
-		},
 	} as const;
 
 	type CompressionPresetKey = keyof typeof COMPRESSION_PRESETS;

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import LabeledInput from '$lib/components/labeled/LabeledInput.svelte';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import { Badge } from '@repo/ui/badge';
+	import { Checkbox } from '@repo/ui/checkbox';
+	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { cn } from '@repo/ui/utils';
+	import { RotateCcw } from '@lucide/svelte';
+	import { isUsingCpalMethodWithoutWhisperCpp } from '../../../routes/+layout/check-ffmpeg';
+	import { createQuery } from '@tanstack/svelte-query';
+	import { rpc } from '$lib/query';
+
+	// Compression preset definitions (UI only - not stored in settings)
+	const COMPRESSION_PRESETS = {
+		recommended: {
+			label: 'Recommended',
+			icon: '🎯',
+			description: 'Best balance for speech',
+			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
+			size: '~240KB/min',
+		},
+		tiny: {
+			label: 'Smallest',
+			icon: '🗜️',
+			description: 'Maximum compression',
+			options: '-c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+			size: '~120KB/min',
+		},
+		compatible: {
+			label: 'Compatible',
+			icon: '✅',
+			description: 'Universal MP3',
+			options: '-c:a libmp3lame -b:a 32k -ar 16000 -ac 1 -q:a 9',
+			size: '~240KB/min',
+		},
+		quality: {
+			label: 'High Quality',
+			icon: '🎵',
+			description: 'Less compression',
+			options: '-c:a libmp3lame -b:a 64k -ar 16000 -ac 1 -q:a 2',
+			size: '~480KB/min',
+		},
+	} as const;
+
+	type CompressionPresetKey = keyof typeof COMPRESSION_PRESETS;
+
+	/**
+	 * Checks if a compression preset is currently active
+	 * @param presetKey The preset key to check
+	 * @returns true if the preset's options match current settings
+	 */
+	function isPresetActive(presetKey: CompressionPresetKey): boolean {
+		return (
+			settings.value['transcription.compressionOptions'] ===
+			COMPRESSION_PRESETS[presetKey].options
+		);
+	}
+
+	// Check if FFmpeg is installed
+	const ffmpegQuery = createQuery(rpc.ffmpeg.checkFfmpegInstalled.options);
+
+	const isFfmpegInstalled = $derived(ffmpegQuery.data ?? false);
+	const isFfmpegCheckLoading = $derived(ffmpegQuery.isPending);
+
+	// Check if we should show "Recommended" badge
+	const shouldShowRecommendedBadge = $derived(
+		isUsingCpalMethodWithoutWhisperCpp() &&
+			!settings.value['transcription.compressionEnabled'],
+	);
+</script>
+
+<div class="space-y-4">
+	<!-- Enable/Disable Toggle -->
+	<div class="flex items-center gap-3">
+		<Checkbox
+			id="compression-enabled-{Math.random().toString(36).substr(2, 9)}"
+			checked={settings.value['transcription.compressionEnabled']}
+			onCheckedChange={(checked) => {
+				settings.updateKey('transcription.compressionEnabled', checked);
+			}}
+			disabled={!isFfmpegInstalled || isFfmpegCheckLoading}
+		/>
+		<div class="flex-1">
+			<div class="flex items-center gap-2">
+				<label
+					for="compression-enabled"
+					class={cn(
+						'text-sm font-medium',
+						(!isFfmpegInstalled || isFfmpegCheckLoading) &&
+							'text-muted-foreground',
+					)}
+				>
+					Compress audio before transcription
+				</label>
+				{#if shouldShowRecommendedBadge && isFfmpegInstalled}
+					<Badge variant="secondary" class="text-xs">Recommended</Badge>
+				{/if}
+				{#if !isFfmpegInstalled && !isFfmpegCheckLoading}
+					<Badge variant="destructive" class="text-xs">FFmpeg Required</Badge>
+				{/if}
+			</div>
+			<p
+				class={cn(
+					'text-xs mt-1',
+					!isFfmpegInstalled || isFfmpegCheckLoading
+						? 'text-muted-foreground/50'
+						: 'text-muted-foreground',
+				)}
+			>
+				{#if !isFfmpegInstalled && !isFfmpegCheckLoading}
+					FFmpeg is required for audio compression.
+					<a
+						href="/install-ffmpeg"
+						class="text-primary underline-offset-4 hover:underline"
+					>
+						Install FFmpeg
+					</a>
+					to enable this feature.
+				{:else if isFfmpegCheckLoading}
+					Checking FFmpeg installation...
+				{:else}
+					Reduce file sizes by ~6x for faster uploads and lower API costs
+				{/if}
+			</p>
+		</div>
+	</div>
+
+	{#if isUsingCpalMethodWithoutWhisperCpp() && !settings.value['transcription.compressionEnabled'] && isFfmpegInstalled}
+		<p class="text-muted-foreground text-sm ml-6">
+			Recommended because you're using CPAL recording with cloud transcription.
+			Compression reduces file sizes for faster uploads and lower API costs.
+		</p>
+	{/if}
+
+	{#if settings.value['transcription.compressionEnabled']}
+		<!-- Preset Selection Badges -->
+		<div class="space-y-3">
+			<p class="text-base font-medium">Compression Presets</p>
+			<div class="flex flex-wrap gap-2">
+				{#each Object.entries(COMPRESSION_PRESETS) as [presetKey, preset]}
+					<Badge
+						variant={isPresetActive(presetKey as CompressionPresetKey)
+							? 'default'
+							: 'outline'}
+						class={cn(
+							'cursor-pointer transition-colors',
+							isPresetActive(presetKey as CompressionPresetKey)
+								? 'hover:bg-primary/90'
+								: 'hover:bg-accent hover:text-accent-foreground',
+						)}
+						onclick={() =>
+							settings.updateKey(
+								'transcription.compressionOptions',
+								preset.options,
+							)}
+					>
+						<div class="flex items-center gap-1">
+							<span class="mr-1">{preset.icon}</span>
+							<span>{preset.label}</span>
+						</div>
+						<span class="text-xs ml-1 opacity-75">
+							{preset.size}
+						</span>
+					</Badge>
+				{/each}
+			</div>
+			<p class="text-muted-foreground text-xs">
+				Choose a preset to automatically set FFmpeg compression options, or
+				customize below.
+			</p>
+		</div>
+
+		<!-- Custom Options Input -->
+		<LabeledInput
+			id="compression-options-{Math.random().toString(36).substr(2, 9)}"
+			label="Custom Options"
+			value={settings.value['transcription.compressionOptions']}
+			oninput={({ currentTarget: { value } }) => {
+				settings.updateKey('transcription.compressionOptions', value);
+			}}
+			placeholder={FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
+			description="FFmpeg compression options. Changes here will be reflected in real-time during transcription."
+		>
+			{#snippet actionSlot()}
+				{#if settings.value['transcription.compressionOptions'] !== FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
+					<WhisperingButton
+						tooltipContent="Reset to default"
+						variant="ghost"
+						size="icon"
+						class="h-6 w-6"
+						onclick={() => {
+							settings.updateKey(
+								'transcription.compressionOptions',
+								FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
+							);
+						}}
+					>
+						<RotateCcw class="h-3 w-3" />
+					</WhisperingButton>
+				{/if}
+			{/snippet}
+		</LabeledInput>
+
+		<!-- Command Preview -->
+		<div class="text-xs text-muted-foreground">
+			<p class="font-medium mb-1">Command Preview:</p>
+			<code class="bg-muted rounded px-2 py-1 text-xs break-all block">
+				ffmpeg -i input.wav {settings.value['transcription.compressionOptions']}
+				output.opus
+			</code>
+		</div>
+	{/if}
+</div>

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -17,13 +17,15 @@
 			label: 'Recommended',
 			icon: '🎯',
 			description: 'Best for speech with silence removal',
-			options: '-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
+			options:
+				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
 		},
 		smallest: {
 			label: 'Smallest',
 			icon: '🗜️',
 			description: 'Maximum compression with silence removal',
-			options: '-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+			options:
+				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
 		},
 		preserve: {
 			label: 'Preserve Audio',
@@ -122,7 +124,8 @@
 				{:else if isFfmpegCheckLoading}
 					Checking FFmpeg installation...
 				{:else}
-					Reduce file sizes and trim silence for faster uploads and lower API costs
+					Reduce file sizes and trim silence for faster uploads and lower API
+					costs
 				{/if}
 			</p>
 		</div>
@@ -141,12 +144,14 @@
 			<p class="text-base font-medium">Compression Presets</p>
 			<div class="flex flex-wrap gap-2">
 				{#each Object.entries(COMPRESSION_PRESETS) as [presetKey, preset]}
-					<Badge
+					<WhisperingButton
+						tooltipContent={preset.description}
 						variant={isPresetActive(presetKey as CompressionPresetKey)
 							? 'default'
 							: 'outline'}
+						size="sm"
 						class={cn(
-							'cursor-pointer transition-colors',
+							'cursor-pointer transition-colors h-auto px-2 py-1',
 							isPresetActive(presetKey as CompressionPresetKey)
 								? 'hover:bg-primary/90'
 								: 'hover:bg-accent hover:text-accent-foreground',
@@ -159,7 +164,7 @@
 					>
 						<span class="mr-1">{preset.icon}</span>
 						<span>{preset.label}</span>
-					</Badge>
+					</WhisperingButton>
 				{/each}
 			</div>
 			<p class="text-muted-foreground text-xs">

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -16,30 +16,32 @@
 		recommended: {
 			label: 'Recommended',
 			icon: '🎯',
-			description: 'Best balance for speech',
-			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
-			size: '~240KB/min',
+			description: 'Best for speech with silence removal',
+			options: '-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
 		},
-		tiny: {
+		smallest: {
 			label: 'Smallest',
 			icon: '🗜️',
-			description: 'Maximum compression',
-			options: '-c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
-			size: '~120KB/min',
+			description: 'Maximum compression with silence removal',
+			options: '-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+		},
+		preserve: {
+			label: 'Preserve Audio',
+			icon: '📼',
+			description: 'Compress but keep all audio',
+			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
 		},
 		compatible: {
-			label: 'Compatible',
+			label: 'MP3',
 			icon: '✅',
-			description: 'Universal MP3',
+			description: 'Universal compatibility',
 			options: '-c:a libmp3lame -b:a 32k -ar 16000 -ac 1 -q:a 9',
-			size: '~240KB/min',
 		},
 		quality: {
 			label: 'High Quality',
 			icon: '🎵',
-			description: 'Less compression',
+			description: 'Less compression, keep everything',
 			options: '-c:a libmp3lame -b:a 64k -ar 16000 -ac 1 -q:a 2',
-			size: '~480KB/min',
 		},
 	} as const;
 
@@ -155,19 +157,13 @@
 								preset.options,
 							)}
 					>
-						<div class="flex items-center gap-1">
-							<span class="mr-1">{preset.icon}</span>
-							<span>{preset.label}</span>
-						</div>
-						<span class="text-xs ml-1 opacity-75">
-							{preset.size}
-						</span>
+						<span class="mr-1">{preset.icon}</span>
+						<span>{preset.label}</span>
 					</Badge>
 				{/each}
 			</div>
 			<p class="text-muted-foreground text-xs">
-				Choose a preset to automatically set FFmpeg compression options, or
-				customize below.
+				Choose a preset or customize FFmpeg options below
 			</p>
 		</div>
 

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -120,7 +120,7 @@
 				{:else if isFfmpegCheckLoading}
 					Checking FFmpeg installation...
 				{:else}
-					Reduce file sizes by ~6x for faster uploads and lower API costs
+					Reduce file sizes and trim silence for faster uploads and lower API costs
 				{/if}
 			</p>
 		</div>

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -20,18 +20,18 @@
 			options:
 				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
 		},
+		preserve: {
+			label: 'Preserve Audio',
+			icon: '📼',
+			description: 'Compress but keep all audio',
+			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
+		},
 		smallest: {
 			label: 'Smallest',
 			icon: '🗜️',
 			description: 'Maximum compression with silence removal',
 			options:
 				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
-		},
-		preserve: {
-			label: 'Preserve Audio',
-			icon: '📼',
-			description: 'Compress but keep all audio',
-			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
 		},
 		compatible: {
 			label: 'MP3',

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -17,8 +17,7 @@
 			label: 'Recommended',
 			icon: '🎯',
 			description: 'Best for speech with silence removal',
-			options:
-				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
+			options: FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
 		},
 		preserve: {
 			label: 'Preserve Audio',

--- a/apps/whispering/src/lib/components/settings/index.ts
+++ b/apps/whispering/src/lib/components/settings/index.ts
@@ -6,8 +6,11 @@ export { default as ElevenLabsApiKeyInput } from './api-key-inputs/ElevenLabsApi
 export { default as GoogleApiKeyInput } from './api-key-inputs/GoogleApiKeyInput.svelte';
 export { default as DeepgramApiKeyInput } from './api-key-inputs/DeepgramApiKeyInput.svelte';
 export { default as OpenRouterApiKeyInput } from './api-key-inputs/OpenRouterApiKeyInput.svelte';
+// Shared components  
+export { default as CompressionBody } from './CompressionBody.svelte';
 // Selector components
 export { default as ManualDeviceSelector } from './selectors/ManualDeviceSelector.svelte';
 export { default as VadDeviceSelector } from './selectors/VadDeviceSelector.svelte';
 export { default as TransformationSelector } from './selectors/TransformationSelector.svelte';
 export { default as TranscriptionSelector } from './selectors/TranscriptionSelector.svelte';
+export { default as CompressionSelector } from './selectors/CompressionSelector.svelte';

--- a/apps/whispering/src/lib/components/settings/index.ts
+++ b/apps/whispering/src/lib/components/settings/index.ts
@@ -9,6 +9,7 @@ export { default as OpenRouterApiKeyInput } from './api-key-inputs/OpenRouterApi
 // Shared components  
 export { default as CompressionBody } from './CompressionBody.svelte';
 // Selector components
+export { default as RecordingModeSelector } from './selectors/RecordingModeSelector.svelte';
 export { default as ManualDeviceSelector } from './selectors/ManualDeviceSelector.svelte';
 export { default as VadDeviceSelector } from './selectors/VadDeviceSelector.svelte';
 export { default as TransformationSelector } from './selectors/TransformationSelector.svelte';

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import { CompressionBody } from '$lib/components/settings';
 	import * as Popover from '@repo/ui/popover';
+	import { Button } from '@repo/ui/button';
+	import { Separator } from '@repo/ui/separator';
 	import { useCombobox } from '@repo/ui/hooks';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
 	import { isUsingCpalMethodWithoutWhisperCpp } from '../../../../routes/+layout/check-ffmpeg';
-	import { PackageIcon } from '@lucide/svelte';
+	import { PackageIcon, SettingsIcon } from '@lucide/svelte';
 
 	let { class: className }: { class?: string } = $props();
 

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -6,6 +6,7 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
 	import { isUsingCpalMethodWithoutWhisperCpp } from '../../../../routes/+layout/check-ffmpeg';
+	import { PackageIcon } from '@lucide/svelte';
 
 	let { class: className }: { class?: string } = $props();
 
@@ -35,14 +36,14 @@
 				variant="ghost"
 				size="icon"
 			>
-				<span
+				<PackageIcon
 					class={cn(
 						'text-lg',
 						isCompressionEnabled ? 'opacity-100' : 'opacity-60',
 					)}
 				>
 					🗜️
-				</span>
+				</PackageIcon>
 
 				<!-- Recommended badge indicator -->
 				{#if shouldShowRecommendedBadge}

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import { CompressionBody } from '$lib/components/settings';
+	import * as Popover from '@repo/ui/popover';
+	import { useCombobox } from '@repo/ui/hooks';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { cn } from '@repo/ui/utils';
+	import { isUsingCpalMethodWithoutWhisperCpp } from '../../../../routes/+layout/check-ffmpeg';
+
+	let { class: className }: { class?: string } = $props();
+
+	const popover = useCombobox();
+
+	// Check if we should show "Recommended" badge
+	const shouldShowRecommendedBadge = $derived(
+		isUsingCpalMethodWithoutWhisperCpp() &&
+			!settings.value['transcription.compressionEnabled'],
+	);
+
+	// Visual state for the button icon
+	const isCompressionEnabled = $derived(
+		settings.value['transcription.compressionEnabled'],
+	);
+</script>
+
+<Popover.Root bind:open={popover.open}>
+	<Popover.Trigger bind:ref={popover.triggerRef}>
+		{#snippet child({ props })}
+			<WhisperingButton
+				{...props}
+				class={cn('relative', className)}
+				tooltipContent={isCompressionEnabled
+					? 'Compression enabled - click to configure'
+					: 'Audio compression disabled - click to enable'}
+				variant="ghost"
+				size="icon"
+			>
+				<span
+					class={cn(
+						'text-lg',
+						isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+					)}
+				>
+					🗜️
+				</span>
+
+				<!-- Recommended badge indicator -->
+				{#if shouldShowRecommendedBadge}
+					<span
+						class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+					></span>
+				{/if}
+			</WhisperingButton>
+		{/snippet}
+	</Popover.Trigger>
+
+	<Popover.Content class="w-full max-w-xl max-h-[40vh] overflow-auto">
+		<CompressionBody />
+	</Popover.Content>
+</Popover.Root>

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -58,7 +58,7 @@
 		{/snippet}
 	</Popover.Trigger>
 
-	<Popover.Content class="w-full max-w-xl max-h-[40vh] overflow-auto p-0">
+	<Popover.Content class="sm:w-[36rem] max-h-[40vh] overflow-auto p-0">
 		<div class="p-4">
 			<CompressionBody />
 		</div>

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -55,7 +55,22 @@
 		{/snippet}
 	</Popover.Trigger>
 
-	<Popover.Content class="w-full max-w-xl max-h-[40vh] overflow-auto">
-		<CompressionBody />
+	<Popover.Content class="w-full max-w-xl max-h-[40vh] overflow-auto p-0">
+		<div class="p-4">
+			<CompressionBody />
+		</div>
+		<Separator />
+		<Button
+			variant="ghost"
+			size="sm"
+			class="w-full justify-start text-muted-foreground rounded-none"
+			onclick={() => {
+				goto('/settings/transcription');
+				popover.open = false;
+			}}
+		>
+			<SettingsIcon class="mr-2 h-4 w-4" />
+			Configure in transcription settings
+		</Button>
 	</Popover.Content>
 </Popover.Root>

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -12,10 +12,12 @@
 
 	const combobox = useCombobox();
 
-	const selectedDeviceId = $derived(
-		settings.value['recording.manual.selectedDeviceId'],
-	);
 	const selectedMethod = $derived(settings.value['recording.method']);
+
+	// Get the device ID for the current method
+	const selectedDeviceId = $derived(
+		settings.value[`recording.${selectedMethod}.deviceId`],
+	);
 
 	const isDeviceSelected = $derived(!!selectedDeviceId);
 
@@ -40,8 +42,6 @@
 			isAvailable: true, // Always available
 		},
 	} as const;
-
-	type RecordingMethod = keyof typeof RECORDING_METHODS;
 
 	const getDevicesQuery = createQuery(() => ({
 		...rpc.recorder.enumerateDevices.options(),
@@ -91,6 +91,7 @@
 								value={`method-${methodKey} ${method.label} ${method.description}`}
 								onSelect={() => {
 									settings.updateKey('recording.method', methodKey);
+									getDevicesQuery.refetch();
 								}}
 								class="flex items-center gap-3 px-3 py-2"
 							>
@@ -138,7 +139,7 @@
 								onSelect={() => {
 									const currentDeviceId = selectedDeviceId;
 									settings.updateKey(
-										'recording.manual.selectedDeviceId',
+										`recording.${selectedMethod}.deviceId`,
 										currentDeviceId === device.id ? null : device.id,
 									);
 								}}

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -30,7 +30,7 @@
 		},
 		ffmpeg: {
 			label: 'FFmpeg',
-			description: 'Command-line recording with advanced options',
+			description: 'Customizable command-line recording',
 			badge: 'Advanced',
 			isAvailable: window.__TAURI_INTERNALS__, // Desktop only
 		},
@@ -111,7 +111,7 @@
 											{method.badge}
 										</Badge>
 									</div>
-									<p class="text-xs text-muted-foreground mb-1">
+									<p class="text-xs text-muted-foreground mt-1">
 										{method.description}
 									</p>
 								</div>
@@ -142,7 +142,6 @@
 										settingKey,
 										currentDeviceId === device.id ? null : device.id,
 									);
-									combobox.closeAndFocusTrigger();
 								}}
 								class="flex items-center gap-3 px-3 py-2"
 							>

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -12,10 +12,9 @@
 
 	const combobox = useCombobox();
 
-	// Setting key for manual mode
-	const settingKey = 'recording.manual.selectedDeviceId';
-
-	const selectedDeviceId = $derived(settings.value[settingKey]);
+	const selectedDeviceId = $derived(
+		settings.value['recording.manual.selectedDeviceId'],
+	);
 	const selectedMethod = $derived(settings.value['recording.method']);
 
 	const isDeviceSelected = $derived(!!selectedDeviceId);
@@ -139,7 +138,7 @@
 								onSelect={() => {
 									const currentDeviceId = selectedDeviceId;
 									settings.updateKey(
-										settingKey,
+										'recording.manual.selectedDeviceId',
 										currentDeviceId === device.id ? null : device.id,
 									);
 								}}

--- a/apps/whispering/src/lib/components/settings/selectors/RecordingModeSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/RecordingModeSelector.svelte
@@ -10,7 +10,7 @@
 	import { rpc } from '$lib/query';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
-	import { CheckIcon } from '@lucide/svelte';
+	import { CheckIcon, ChevronDown } from '@lucide/svelte';
 
 	let { class: className }: { class?: string } = $props();
 
@@ -45,9 +45,7 @@
 				variant="ghost"
 				size="icon"
 			>
-				<span class="text-base">
-					{currentMode?.icon ?? '🎙️'}
-				</span>
+				<ChevronDown class="size-4" />
 			</WhisperingButton>
 		{/snippet}
 	</Popover.Trigger>

--- a/apps/whispering/src/lib/components/settings/selectors/RecordingModeSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/RecordingModeSelector.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import * as Command from '@repo/ui/command';
+	import * as Popover from '@repo/ui/popover';
+	import { useCombobox } from '@repo/ui/hooks';
+	import {
+		RECORDING_MODE_OPTIONS,
+		type RecordingMode,
+	} from '$lib/constants/audio';
+	import { rpc } from '$lib/query';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { cn } from '@repo/ui/utils';
+	import { CheckIcon } from '@lucide/svelte';
+
+	let { class: className }: { class?: string } = $props();
+
+	const combobox = useCombobox();
+
+	const availableModes = $derived(
+		RECORDING_MODE_OPTIONS.filter((mode) => {
+			if (!mode.desktopOnly) return true;
+			// Desktop only, only show if Tauri is available
+			return window.__TAURI_INTERNALS__;
+		}),
+	);
+
+	const currentMode = $derived(
+		availableModes.find(
+			(mode) => mode.value === settings.value['recording.mode'],
+		),
+	);
+</script>
+
+<Popover.Root bind:open={combobox.open}>
+	<Popover.Trigger bind:ref={combobox.triggerRef}>
+		{#snippet child({ props })}
+			<WhisperingButton
+				{...props}
+				class={cn('relative', className)}
+				tooltipContent={currentMode
+					? `Recording mode: ${currentMode.label}`
+					: 'Select recording mode'}
+				role="combobox"
+				aria-expanded={combobox.open}
+				variant="ghost"
+				size="icon"
+			>
+				<span class="text-base">
+					{currentMode?.icon ?? '🎙️'}
+				</span>
+			</WhisperingButton>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="p-0 w-48">
+		<Command.Root loop>
+			<Command.List>
+				<Command.Group>
+					{#each availableModes as mode (mode.value)}
+						{@const isSelected =
+							settings.value['recording.mode'] === mode.value}
+						<Command.Item
+							value={mode.value}
+							onSelect={async () => {
+								await rpc.settings.switchRecordingMode.execute(
+									mode.value as RecordingMode,
+								);
+								combobox.closeAndFocusTrigger();
+							}}
+							class="flex items-center gap-2 px-2 py-2"
+						>
+							<CheckIcon
+								class={cn('size-3.5 shrink-0', {
+									'text-transparent': !isSelected,
+								})}
+							/>
+							<span class="text-base">{mode.icon}</span>
+							<span class="text-sm">{mode.label}</span>
+						</Command.Item>
+					{/each}
+				</Command.Group>
+			</Command.List>
+		</Command.Root>
+	</Popover.Content>
+</Popover.Root>

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -52,7 +52,7 @@
 			</WhisperingButton>
 		{/snippet}
 	</Popover.Trigger>
-	<Popover.Content class="w-80 max-w-xl p-0">
+	<Popover.Content class="p-0">
 		<Command.Root loop>
 			<Command.Input placeholder="Select VAD recording device..." />
 			<Command.Empty>No recording devices found.</Command.Empty>

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -11,8 +11,8 @@
 
 	const combobox = useCombobox();
 
-	// Setting key for VAD mode
-	const settingKey = 'recording.vad.selectedDeviceId';
+	// VAD always uses navigator device ID
+	const settingKey = 'recording.navigator.deviceId';
 
 	const selectedDeviceId = $derived(settings.value[settingKey]);
 

--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -48,8 +48,9 @@ const startManualRecording = defineMutation({
 				break;
 			}
 			case 'fallback': {
+				const method = settings.value['recording.method'];
 				settings.updateKey(
-					'recording.manual.selectedDeviceId',
+					`recording.${method}.deviceId`,
 					deviceAcquisitionOutcome.deviceId,
 				);
 				switch (deviceAcquisitionOutcome.reason) {

--- a/apps/whispering/src/lib/query/recorder.ts
+++ b/apps/whispering/src/lib/query/recorder.ts
@@ -65,7 +65,6 @@ export const recorder = {
 
 			// Prepare recording parameters based on which method we're using
 			const baseParams = {
-				selectedDeviceId: settings.value['recording.manual.selectedDeviceId'],
 				recordingId,
 			};
 
@@ -79,11 +78,13 @@ export const recorder = {
 				navigator: {
 					...baseParams,
 					method: 'navigator' as const,
+					selectedDeviceId: settings.value['recording.navigator.deviceId'],
 					bitrateKbps: settings.value['recording.navigator.bitrateKbps'],
 				},
 				ffmpeg: {
 					...baseParams,
 					method: 'ffmpeg' as const,
+					selectedDeviceId: settings.value['recording.ffmpeg.deviceId'],
 					globalOptions: settings.value['recording.ffmpeg.globalOptions'],
 					inputOptions: settings.value['recording.ffmpeg.inputOptions'],
 					outputOptions: settings.value['recording.ffmpeg.outputOptions'],
@@ -92,6 +93,7 @@ export const recorder = {
 				cpal: {
 					...baseParams,
 					method: 'cpal' as const,
+					selectedDeviceId: settings.value['recording.cpal.deviceId'],
 					outputFolder,
 					sampleRate: settings.value['recording.cpal.sampleRate'],
 				},
@@ -101,7 +103,7 @@ export const recorder = {
 				paramsMap[
 					!window.__TAURI_INTERNALS__
 						? 'navigator'
-						: settings.value['recording.manual.method']
+						: settings.value['recording.method']
 				];
 
 			const { data: deviceAcquisitionOutcome, error: startRecordingError } =
@@ -176,7 +178,5 @@ export function recorderService() {
 		ffmpeg: services.ffmpegRecorder,
 		cpal: services.cpalRecorder,
 	};
-
-	// Return the selected recorder or fallback to navigator
-	return recorderMap[settings.value['recording.manual.method']];
+	return recorderMap[settings.value['recording.method']];
 }

--- a/apps/whispering/src/lib/query/recorder.ts
+++ b/apps/whispering/src/lib/query/recorder.ts
@@ -101,7 +101,7 @@ export const recorder = {
 				paramsMap[
 					!window.__TAURI_INTERNALS__
 						? 'navigator'
-						: settings.value['recording.method']
+						: settings.value['recording.manual.method']
 				];
 
 			const { data: deviceAcquisitionOutcome, error: startRecordingError } =
@@ -178,5 +178,5 @@ export function recorderService() {
 	};
 
 	// Return the selected recorder or fallback to navigator
-	return recorderMap[settings.value['recording.method']];
+	return recorderMap[settings.value['recording.manual.method']];
 }

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -126,11 +126,11 @@ async function transcribeBlob(
 	// Compress audio if enabled, else pass through original blob
 	let audioToTranscribe = blob;
 	if (settings.value['transcription.compressionEnabled']) {
-		const compressionOptions =
-			settings.value['transcription.compressionOptions'];
-
 		const { data: compressedBlob, error: compressionError } =
-			await services.ffmpeg.compressAudioBlob(blob, compressionOptions);
+			await services.ffmpeg.compressAudioBlob(
+				blob,
+				settings.value['transcription.compressionOptions'],
+			);
 
 		if (compressionError) {
 			// Log compression failure but continue with original blob

--- a/apps/whispering/src/lib/query/vad-recorder.ts
+++ b/apps/whispering/src/lib/query/vad-recorder.ts
@@ -50,7 +50,7 @@ export const vadRecorder = {
 		}) => {
 			const { data: deviceOutcome, error: startListeningError } =
 				await services.vad.startActiveListening({
-					deviceId: settings.value['recording.vad.selectedDeviceId'],
+					deviceId: settings.value['recording.navigator.deviceId'],
 					onSpeechStart: () => {
 						invalidateVadState();
 						onSpeechStart();

--- a/apps/whispering/src/lib/services/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/recorder/ffmpeg.ts
@@ -89,7 +89,7 @@ export const FFMPEG_DEFAULT_OUTPUT_OPTIONS =
  * const command = `ffmpeg -i input.wav ${FFMPEG_DEFAULT_COMPRESSION_OPTIONS} output.opus`;
  */
 export const FFMPEG_DEFAULT_COMPRESSION_OPTIONS =
-	'-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10' as const;
+	'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10' as const;
 
 /**
  * Default FFmpeg input options for the current platform.

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -112,12 +112,12 @@ export const settingsSchema = z.object({
 	// Recording mode settings
 	'recording.mode': z.enum(RECORDING_MODES).default('manual'),
 	/**
-	 * Recording method to use in desktop app.
+	 * Recording method to use for manual recording in desktop app.
 	 * - 'cpal': Uses Rust audio recording method (CPAL)
 	 * - 'navigator': Uses MediaRecorder API (web standard)
 	 * - 'ffmpeg': Uses FFmpeg command-line tool for recording
 	 */
-	'recording.method': z.enum(['cpal', 'navigator', 'ffmpeg']).default('cpal'),
+	'recording.manual.method': z.enum(['cpal', 'navigator', 'ffmpeg']).default('cpal'),
 	/**
 	 * Device identifier for manual recording.
 	 * Can be either a desktop device identifier or navigator device ID.

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -117,25 +117,24 @@ export const settingsSchema = z.object({
 	 * - 'navigator': Uses MediaRecorder API (web standard)
 	 * - 'ffmpeg': Uses FFmpeg command-line tool for recording
 	 */
-	'recording.manual.method': z.enum(['cpal', 'navigator', 'ffmpeg']).default('cpal'),
+	'recording.method': z.enum(['cpal', 'navigator', 'ffmpeg']).default('cpal'),
+
 	/**
-	 * Device identifier for manual recording.
-	 * Can be either a desktop device identifier or navigator device ID.
-	 * @see DeviceIdentifier
+	 * Device identifiers for each recording method.
+	 * Each method remembers its own selected device.
+	 * Note: VAD always uses navigator, so it shares the same device ID.
 	 */
-	'recording.manual.selectedDeviceId': z
+	'recording.cpal.deviceId': z
 		.string()
 		.nullable()
 		.transform((val) => (val ? asDeviceIdentifier(val) : null))
 		.default(null),
-
-	/**
-	 * Device identifier for VAD recording.
-	 * Always a navigator device ID due to the nature of VAD recording
-	 * (it uses a MediaStream to track voice activity)
-	 * @see DeviceIdentifier
-	 */
-	'recording.vad.selectedDeviceId': z
+	'recording.navigator.deviceId': z
+		.string()
+		.nullable()
+		.transform((val) => (val ? asDeviceIdentifier(val) : null))
+		.default(null),
+	'recording.ffmpeg.deviceId': z
 		.string()
 		.nullable()
 		.transform((val) => (val ? asDeviceIdentifier(val) : null))
@@ -171,7 +170,6 @@ export const settingsSchema = z.object({
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
 	'transcription.temperature': z.string().default('0.0'),
-	
 	// Audio compression settings
 	'transcription.compressionEnabled': z.boolean().default(false),
 	'transcription.compressionOptions': z

--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -6,12 +6,14 @@ import {
 	parseStoredSettings,
 	settingsSchema,
 } from '$lib/settings/settings';
+import { enumerateDevices } from '$lib/services/device-stream';
 import { createPersistedState } from '@repo/svelte-utils';
 import {
 	syncGlobalShortcutsWithSettings,
 	syncLocalShortcutsWithSettings,
 } from '../../routes/+layout/register-commands';
 import { extractErrorMessage } from 'wellcrafted/error';
+import * as services from '$lib/services';
 
 /**
  * Encapsulated settings object with controlled access.

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -87,6 +87,10 @@
 		>
 			{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
 		</WhisperingButton>
+	{:else if settings.value['recording.mode'] === 'upload'}
+		<CompressionSelector />
+		<TranscriptionSelector />
+		<TransformationSelector />
 	{:else if settings.value['recording.mode'] === 'live'}
 		{#if true}
 			<ManualDeviceSelector />

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -3,7 +3,7 @@
 	import NavItems from '$lib/components/NavItems.svelte';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import {
-	CompressionSelector,
+		CompressionSelector,
 		TranscriptionSelector,
 		TransformationSelector,
 	} from '$lib/components/settings';
@@ -33,7 +33,7 @@
 	)}
 	style="view-transition-name: header"
 >
-	<div class="mr-auto flex gap-2">
+	<div class="mr-auto">
 		<WhisperingButton
 			tooltipContent="Go home"
 			href="/"

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -3,15 +3,13 @@
 	import NavItems from '$lib/components/NavItems.svelte';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import {
+	CompressionSelector,
 		TranscriptionSelector,
 		TransformationSelector,
 	} from '$lib/components/settings';
 	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
 	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
-	import {
-		recorderStateToIcons,
-		vadStateToIcons,
-	} from '$lib/constants/audio';
+	import { recorderStateToIcons, vadStateToIcons } from '$lib/constants/audio';
 	import { rpc } from '$lib/query';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
@@ -58,6 +56,7 @@
 			</WhisperingButton>
 		{:else}
 			<ManualDeviceSelector />
+			<CompressionSelector />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
@@ -75,6 +74,7 @@
 	{:else if settings.value['recording.mode'] === 'vad'}
 		{#if getVadStateQuery.data === 'IDLE'}
 			<VadDeviceSelector />
+			<CompressionSelector />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
@@ -90,6 +90,7 @@
 	{:else if settings.value['recording.mode'] === 'live'}
 		{#if true}
 			<ManualDeviceSelector />
+			<CompressionSelector />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -3,6 +3,7 @@
 	import NavItems from '$lib/components/NavItems.svelte';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import {
+		RecordingModeSelector,
 		CompressionSelector,
 		TranscriptionSelector,
 		TransformationSelector,
@@ -55,6 +56,7 @@
 				🚫
 			</WhisperingButton>
 		{:else}
+			<RecordingModeSelector />
 			<ManualDeviceSelector />
 			<CompressionSelector />
 			<TranscriptionSelector />
@@ -73,6 +75,7 @@
 		</WhisperingButton>
 	{:else if settings.value['recording.mode'] === 'vad'}
 		{#if getVadStateQuery.data === 'IDLE'}
+			<RecordingModeSelector />
 			<VadDeviceSelector />
 			<CompressionSelector />
 			<TranscriptionSelector />
@@ -88,16 +91,16 @@
 			{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
 		</WhisperingButton>
 	{:else if settings.value['recording.mode'] === 'upload'}
+		<RecordingModeSelector />
 		<CompressionSelector />
 		<TranscriptionSelector />
 		<TransformationSelector />
 	{:else if settings.value['recording.mode'] === 'live'}
-		{#if true}
-			<ManualDeviceSelector />
-			<CompressionSelector />
-			<TranscriptionSelector />
-			<TransformationSelector />
-		{/if}
+		<RecordingModeSelector />
+		<ManualDeviceSelector />
+		<CompressionSelector />
+		<TranscriptionSelector />
+		<TransformationSelector />
 		<WhisperingButton
 			tooltipContent="Toggle live recording"
 			onclick={() => {

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -30,123 +30,125 @@
 <header
 	class={cn(
 		'border-border/40 bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-50 border-b shadow-xs backdrop-blur-sm ',
-		'flex h-14 w-full items-center px-4 sm:px-8 gap-1.5',
+		'flex h-14 w-full items-center justify-between px-4 sm:px-8',
 	)}
 	style="view-transition-name: header"
 >
-	<div class="mr-auto">
-		<WhisperingButton
-			tooltipContent="Go home"
-			href="/"
-			variant="ghost"
-			class="-ml-4"
-		>
-			<span class="text-lg font-bold">whispering</span>
-		</WhisperingButton>
-	</div>
-	{#if settings.value['recording.mode'] === 'manual'}
-		{#if getRecorderStateQuery.data === 'RECORDING'}
-			<WhisperingButton
-				tooltipContent="Cancel recording"
-				onclick={commandCallbacks.cancelManualRecording}
-				variant="ghost"
-				size="icon"
-				style="view-transition-name: cancel-icon;"
-			>
-				🚫
-			</WhisperingButton>
-		{:else}
-			<ManualDeviceSelector />
-			<CompressionSelector />
-			<TranscriptionSelector />
-			<TransformationSelector />
-		{/if}
-		{#if getRecorderStateQuery.data === 'RECORDING'}
-			<WhisperingButton
-				tooltipContent="Stop recording"
-				onclick={commandCallbacks.toggleManualRecording}
-				variant="ghost"
-				size="icon"
-				style="view-transition-name: microphone-icon"
-			>
-				{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-			</WhisperingButton>
-		{:else}
-			<div class="flex">
-				<WhisperingButton
-					tooltipContent="Start recording"
-					onclick={commandCallbacks.toggleManualRecording}
-					variant="ghost"
-					size="icon"
-					style="view-transition-name: microphone-icon"
-					class="rounded-r-none border-r-0"
-				>
-					{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-				</WhisperingButton>
-				<RecordingModeSelector class="rounded-l-none" />
-			</div>
-		{/if}
-	{:else if settings.value['recording.mode'] === 'vad'}
-		{#if getVadStateQuery.data === 'IDLE'}
-			<VadDeviceSelector />
-			<CompressionSelector />
-			<TranscriptionSelector />
-			<TransformationSelector />
-		{/if}
-		{#if getVadStateQuery.data === 'IDLE'}
-			<div class="flex">
-				<WhisperingButton
-					tooltipContent="Start voice activated recording"
-					onclick={commandCallbacks.toggleVadRecording}
-					variant="ghost"
-					size="icon"
-					style="view-transition-name: microphone-icon"
-					class="rounded-r-none border-r-0"
-				>
-					{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-				</WhisperingButton>
-				<RecordingModeSelector class="rounded-l-none" />
-			</div>
-		{:else}
-			<WhisperingButton
-				tooltipContent="Stop voice activated recording"
-				onclick={commandCallbacks.toggleVadRecording}
-				variant="ghost"
-				size="icon"
-				style="view-transition-name: microphone-icon"
-			>
-				{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-			</WhisperingButton>
-		{/if}
-	{:else if settings.value['recording.mode'] === 'upload'}
-		<CompressionSelector />
-		<TranscriptionSelector />
-		<TransformationSelector />
-		<RecordingModeSelector />
-	{:else if settings.value['recording.mode'] === 'live'}
-		<ManualDeviceSelector />
-		<CompressionSelector />
-		<TranscriptionSelector />
-		<TransformationSelector />
-		<div class="flex">
-			<WhisperingButton
-				tooltipContent="Toggle live recording"
-				onclick={() => {
-					// TODO: Implement live recording toggle
-					alert('Live recording not yet implemented');
-				}}
-				variant="ghost"
-				size="icon"
-				style="view-transition-name: microphone-icon"
-				class="rounded-r-none border-r-0"
-			>
-				🎬
-			</WhisperingButton>
-			<RecordingModeSelector class="rounded-l-none" />
-		</div>
-	{/if}
+	<WhisperingButton
+		tooltipContent="Go home"
+		href="/"
+		variant="ghost"
+		class="-ml-4"
+	>
+		<span class="text-lg font-bold">whispering</span>
+	</WhisperingButton>
 
-	<NavItems class="-mr-4" collapsed={isMobile.current} />
+	<div class="flex">
+		<div class="flex items-center gap-1.5">
+			{#if settings.value['recording.mode'] === 'manual'}
+				{#if getRecorderStateQuery.data === 'RECORDING'}
+					<WhisperingButton
+						tooltipContent="Cancel recording"
+						onclick={commandCallbacks.cancelManualRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: cancel-icon;"
+					>
+						🚫
+					</WhisperingButton>
+				{:else}
+					<ManualDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
+				{/if}
+				{#if getRecorderStateQuery.data === 'RECORDING'}
+					<WhisperingButton
+						tooltipContent="Stop recording"
+						onclick={commandCallbacks.toggleManualRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+					>
+						{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+					</WhisperingButton>
+				{:else}
+					<div class="flex">
+						<WhisperingButton
+							tooltipContent="Start recording"
+							onclick={commandCallbacks.toggleManualRecording}
+							variant="ghost"
+							size="icon"
+							style="view-transition-name: microphone-icon"
+							class="rounded-r-none border-r-0"
+						>
+							{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+						</WhisperingButton>
+						<RecordingModeSelector class="rounded-l-none" />
+					</div>
+				{/if}
+			{:else if settings.value['recording.mode'] === 'vad'}
+				{#if getVadStateQuery.data === 'IDLE'}
+					<VadDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
+				{/if}
+				{#if getVadStateQuery.data === 'IDLE'}
+					<div class="flex">
+						<WhisperingButton
+							tooltipContent="Start voice activated recording"
+							onclick={commandCallbacks.toggleVadRecording}
+							variant="ghost"
+							size="icon"
+							style="view-transition-name: microphone-icon"
+							class="rounded-r-none border-r-0"
+						>
+							{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+						</WhisperingButton>
+						<RecordingModeSelector class="rounded-l-none" />
+					</div>
+				{:else}
+					<WhisperingButton
+						tooltipContent="Stop voice activated recording"
+						onclick={commandCallbacks.toggleVadRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+					>
+						{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+					</WhisperingButton>
+				{/if}
+			{:else if settings.value['recording.mode'] === 'upload'}
+				<CompressionSelector />
+				<TranscriptionSelector />
+				<TransformationSelector />
+				<RecordingModeSelector />
+			{:else if settings.value['recording.mode'] === 'live'}
+				<ManualDeviceSelector />
+				<CompressionSelector />
+				<TranscriptionSelector />
+				<TransformationSelector />
+				<div class="flex">
+					<WhisperingButton
+						tooltipContent="Toggle live recording"
+						onclick={() => {
+							// TODO: Implement live recording toggle
+							alert('Live recording not yet implemented');
+						}}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+						class="rounded-r-none border-r-0"
+					>
+						🎬
+					</WhisperingButton>
+					<RecordingModeSelector class="rounded-l-none" />
+				</div>
+			{/if}
+		</div>
+		<NavItems class="-mr-4" collapsed={isMobile.current} />
+	</div>
 </header>
 
 {@render children()}

--- a/apps/whispering/src/routes/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/+layout.svelte
@@ -56,63 +56,94 @@
 				🚫
 			</WhisperingButton>
 		{:else}
-			<RecordingModeSelector />
 			<ManualDeviceSelector />
 			<CompressionSelector />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
-		<WhisperingButton
-			tooltipContent={getRecorderStateQuery.data === 'RECORDING'
-				? 'Stop recording'
-				: 'Start recording'}
-			onclick={commandCallbacks.toggleManualRecording}
-			variant="ghost"
-			size="icon"
-			style="view-transition-name: microphone-icon"
-		>
-			{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-		</WhisperingButton>
+		{#if getRecorderStateQuery.data === 'RECORDING'}
+			<WhisperingButton
+				tooltipContent="Stop recording"
+				onclick={commandCallbacks.toggleManualRecording}
+				variant="ghost"
+				size="icon"
+				style="view-transition-name: microphone-icon"
+			>
+				{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+			</WhisperingButton>
+		{:else}
+			<div class="flex">
+				<WhisperingButton
+					tooltipContent="Start recording"
+					onclick={commandCallbacks.toggleManualRecording}
+					variant="ghost"
+					size="icon"
+					style="view-transition-name: microphone-icon"
+					class="rounded-r-none border-r-0"
+				>
+					{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+				</WhisperingButton>
+				<RecordingModeSelector class="rounded-l-none" />
+			</div>
+		{/if}
 	{:else if settings.value['recording.mode'] === 'vad'}
 		{#if getVadStateQuery.data === 'IDLE'}
-			<RecordingModeSelector />
 			<VadDeviceSelector />
 			<CompressionSelector />
 			<TranscriptionSelector />
 			<TransformationSelector />
 		{/if}
-		<WhisperingButton
-			tooltipContent="Toggle voice activated recording"
-			onclick={commandCallbacks.toggleVadRecording}
-			variant="ghost"
-			size="icon"
-			style="view-transition-name: microphone-icon"
-		>
-			{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-		</WhisperingButton>
+		{#if getVadStateQuery.data === 'IDLE'}
+			<div class="flex">
+				<WhisperingButton
+					tooltipContent="Start voice activated recording"
+					onclick={commandCallbacks.toggleVadRecording}
+					variant="ghost"
+					size="icon"
+					style="view-transition-name: microphone-icon"
+					class="rounded-r-none border-r-0"
+				>
+					{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+				</WhisperingButton>
+				<RecordingModeSelector class="rounded-l-none" />
+			</div>
+		{:else}
+			<WhisperingButton
+				tooltipContent="Stop voice activated recording"
+				onclick={commandCallbacks.toggleVadRecording}
+				variant="ghost"
+				size="icon"
+				style="view-transition-name: microphone-icon"
+			>
+				{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+			</WhisperingButton>
+		{/if}
 	{:else if settings.value['recording.mode'] === 'upload'}
-		<RecordingModeSelector />
 		<CompressionSelector />
 		<TranscriptionSelector />
 		<TransformationSelector />
-	{:else if settings.value['recording.mode'] === 'live'}
 		<RecordingModeSelector />
+	{:else if settings.value['recording.mode'] === 'live'}
 		<ManualDeviceSelector />
 		<CompressionSelector />
 		<TranscriptionSelector />
 		<TransformationSelector />
-		<WhisperingButton
-			tooltipContent="Toggle live recording"
-			onclick={() => {
-				// TODO: Implement live recording toggle
-				alert('Live recording not yet implemented');
-			}}
-			variant="ghost"
-			size="icon"
-			style="view-transition-name: microphone-icon"
-		>
-			🎬
-		</WhisperingButton>
+		<div class="flex">
+			<WhisperingButton
+				tooltipContent="Toggle live recording"
+				onclick={() => {
+					// TODO: Implement live recording toggle
+					alert('Live recording not yet implemented');
+				}}
+				variant="ghost"
+				size="icon"
+				style="view-transition-name: microphone-icon"
+				class="rounded-r-none border-r-0"
+			>
+				🎬
+			</WhisperingButton>
+			<RecordingModeSelector class="rounded-l-none" />
+		</div>
 	{/if}
 
 	<NavItems class="-mr-4" collapsed={isMobile.current} />

--- a/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
@@ -57,11 +57,11 @@
 
 	const isUsingNavigatorMethod = $derived(
 		!window.__TAURI_INTERNALS__ ||
-			settings.value['recording.method'] === 'navigator',
+			settings.value['recording.manual.method'] === 'navigator',
 	);
 
 	const isUsingFfmpegMethod = $derived(
-		settings.value['recording.method'] === 'ffmpeg',
+		settings.value['recording.manual.method'] === 'ffmpeg',
 	);
 </script>
 
@@ -97,16 +97,16 @@
 			id="recording-method"
 			label="Recording Method"
 			items={RECORDING_METHOD_OPTIONS}
-			selected={settings.value['recording.method']}
+			selected={settings.value['recording.manual.method']}
 			onSelectedChange={(selected) => {
 				settings.updateKey(
-					'recording.method',
+					'recording.manual.method',
 					selected as 'cpal' | 'navigator' | 'ffmpeg',
 				);
 			}}
 			placeholder="Select a recording method"
 			description={RECORDING_METHOD_OPTIONS.find(
-				(option) => option.value === settings.value['recording.method'],
+				(option) => option.value === settings.value['recording.manual.method'],
 			)?.description}
 		>
 			{#snippet renderOption({ item })}
@@ -119,7 +119,7 @@
 			{/snippet}
 		</LabeledSelect>
 
-		{#if settings.value['recording.method'] === 'ffmpeg' && !data.ffmpegInstalled}
+		{#if settings.value['recording.manual.method'] === 'ffmpeg' && !data.ffmpegInstalled}
 			<Alert.Root class="border-red-500/20 bg-red-500/5">
 				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
 				<Alert.Title class="text-red-600 dark:text-red-400">
@@ -136,7 +136,7 @@
 					</Link>
 				</Alert.Description>
 			</Alert.Root>
-		{:else if IS_MACOS && settings.value['recording.method'] === 'navigator'}
+		{:else if IS_MACOS && settings.value['recording.manual.method'] === 'navigator'}
 			<Alert.Root class="border-amber-500/20 bg-amber-500/5">
 				<InfoIcon class="size-4 text-amber-600 dark:text-amber-400" />
 				<Alert.Title class="text-amber-600 dark:text-amber-400">

--- a/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
@@ -28,6 +28,13 @@
 
 	const RECORDING_METHOD_OPTIONS = [
 		{
+			value: 'cpal',
+			label: 'CPAL',
+			description: IS_MACOS
+				? 'Native Rust audio method. Records uncompressed WAV, reliable with shortcuts but creates larger files.'
+				: 'Native Rust audio method. Records uncompressed WAV format, creates larger files.',
+		},
+		{
 			value: 'ffmpeg',
 			label: 'FFmpeg',
 			description: {
@@ -38,13 +45,6 @@
 				windows:
 					'Supports all audio formats with advanced customization options.',
 			}[PLATFORM_TYPE],
-		},
-		{
-			value: 'cpal',
-			label: 'CPAL',
-			description: IS_MACOS
-				? 'Native Rust audio method. Records uncompressed WAV, reliable with shortcuts but creates larger files.'
-				: 'Native Rust audio method. Records uncompressed WAV format, creates larger files.',
 		},
 		{
 			value: 'navigator',

--- a/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/+page.svelte
@@ -11,7 +11,8 @@
 		RECORDING_MODE_OPTIONS,
 	} from '$lib/constants/audio';
 	import { settings } from '$lib/stores/settings.svelte';
-	import SelectRecordingDevice from './SelectRecordingDevice.svelte';
+	import ManualSelectRecordingDevice from './ManualSelectRecordingDevice.svelte';
+	import VadSelectRecordingDevice from './VadSelectRecordingDevice.svelte';
 	import {
 		isUsingCpalMethodWithoutWhisperCpp,
 		isUsingCpalMethodAtWrongSampleRate,
@@ -57,11 +58,11 @@
 
 	const isUsingNavigatorMethod = $derived(
 		!window.__TAURI_INTERNALS__ ||
-			settings.value['recording.manual.method'] === 'navigator',
+			settings.value['recording.method'] === 'navigator',
 	);
 
 	const isUsingFfmpegMethod = $derived(
-		settings.value['recording.manual.method'] === 'ffmpeg',
+		settings.value['recording.method'] === 'ffmpeg',
 	);
 </script>
 
@@ -97,16 +98,16 @@
 			id="recording-method"
 			label="Recording Method"
 			items={RECORDING_METHOD_OPTIONS}
-			selected={settings.value['recording.manual.method']}
+			selected={settings.value['recording.method']}
 			onSelectedChange={(selected) => {
 				settings.updateKey(
-					'recording.manual.method',
+					'recording.method',
 					selected as 'cpal' | 'navigator' | 'ffmpeg',
 				);
 			}}
 			placeholder="Select a recording method"
 			description={RECORDING_METHOD_OPTIONS.find(
-				(option) => option.value === settings.value['recording.manual.method'],
+				(option) => option.value === settings.value['recording.method'],
 			)?.description}
 		>
 			{#snippet renderOption({ item })}
@@ -119,7 +120,7 @@
 			{/snippet}
 		</LabeledSelect>
 
-		{#if settings.value['recording.manual.method'] === 'ffmpeg' && !data.ffmpegInstalled}
+		{#if settings.value['recording.method'] === 'ffmpeg' && !data.ffmpegInstalled}
 			<Alert.Root class="border-red-500/20 bg-red-500/5">
 				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
 				<Alert.Title class="text-red-600 dark:text-red-400">
@@ -136,7 +137,7 @@
 					</Link>
 				</Alert.Description>
 			</Alert.Root>
-		{:else if IS_MACOS && settings.value['recording.manual.method'] === 'navigator'}
+		{:else if IS_MACOS && settings.value['recording.method'] === 'navigator'}
 			<Alert.Root class="border-amber-500/20 bg-amber-500/5">
 				<InfoIcon class="size-4 text-amber-600 dark:text-amber-400" />
 				<Alert.Title class="text-amber-600 dark:text-amber-400">
@@ -190,13 +191,13 @@
 	{/if}
 
 	{#if settings.value['recording.mode'] === 'manual'}
-		<SelectRecordingDevice
-			selected={settings.value['recording.manual.selectedDeviceId']}
+		{@const method = settings.value['recording.method']}
+		<ManualSelectRecordingDevice
+			selected={settings.value[`recording.${method}.deviceId`]}
 			onSelectedChange={(selected) => {
-				settings.updateKey('recording.manual.selectedDeviceId', selected);
+				settings.updateKey(`recording.${method}.deviceId`, selected);
 			}}
-			mode="manual"
-		></SelectRecordingDevice>
+		/>
 	{:else if settings.value['recording.mode'] === 'vad'}
 		<Alert.Root class="border-blue-500/20 bg-blue-500/5">
 			<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
@@ -210,13 +211,12 @@
 			</Alert.Description>
 		</Alert.Root>
 
-		<SelectRecordingDevice
-			selected={settings.value['recording.vad.selectedDeviceId']}
+		<VadSelectRecordingDevice
+			selected={settings.value['recording.navigator.deviceId']}
 			onSelectedChange={(selected) => {
-				settings.updateKey('recording.vad.selectedDeviceId', selected);
+				settings.updateKey('recording.navigator.deviceId', selected);
 			}}
-			mode="vad"
-		></SelectRecordingDevice>
+		/>
 	{/if}
 
 	{#if settings.value['recording.mode'] === 'manual' || settings.value['recording.mode'] === 'vad'}

--- a/apps/whispering/src/routes/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -42,7 +42,7 @@
 	const selectedDeviceId = $derived(
 		// First, try to find the user's selected device
 		getDevicesQuery.data?.find(
-			(d) => d.id === settings.value['recording.manual.selectedDeviceId'],
+			(d) => d.id === settings.value['recording.ffmpeg.deviceId'],
 		)?.id ??
 			// Then fall back to the first available device
 			getDevicesQuery.data?.[0]?.id ??

--- a/apps/whispering/src/routes/(config)/settings/recording/SelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/SelectRecordingDevice.svelte
@@ -22,7 +22,7 @@
 	const isUsingBrowserMethod = $derived(
 		mode === 'vad' || 
 		!window.__TAURI_INTERNALS__ ||
-		settings.value['recording.method'] === 'navigator' 
+		settings.value['recording.manual.method'] === 'navigator' 
 	);
 
 	const getDevicesQuery = createQuery(

--- a/apps/whispering/src/routes/(config)/settings/recording/VadSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(config)/settings/recording/VadSelectRecordingDevice.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { LabeledSelect } from '$lib/components/labeled/index.js';
+	import { rpc } from '$lib/query';
+	import type { DeviceIdentifier } from '$lib/services/types';
+	import { asDeviceIdentifier } from '$lib/services/types';
+	import { createQuery } from '@tanstack/svelte-query';
+
+	let {
+		selected,
+		onSelectedChange,
+	}: {
+		selected: DeviceIdentifier | null;
+		onSelectedChange: (selected: DeviceIdentifier | null) => void;
+	} = $props();
+
+	// Use vadRecorder.enumerateDevices for VAD (navigator devices only)
+	const getDevicesQuery = createQuery(rpc.vadRecorder.enumerateDevices.options);
+
+	$effect(() => {
+		if (getDevicesQuery.isError) {
+			rpc.notify.warning.execute(getDevicesQuery.error);
+		}
+	});
+</script>
+
+{#if getDevicesQuery.isPending}
+	<LabeledSelect
+		id="vad-recording-device"
+		label="VAD Recording Device"
+		placeholder="Loading devices..."
+		items={[{ value: '', label: 'Loading devices...' }]}
+		selected={''}
+		onSelectedChange={() => {}}
+		disabled
+	/>
+{:else if getDevicesQuery.isError}
+	<p class="text-sm text-red-500">
+		{getDevicesQuery.error.title}
+	</p>
+{:else}
+	{@const items = getDevicesQuery.data.map((device) => ({
+		value: device.id,
+		label: device.label,
+	}))}
+	<LabeledSelect
+		id="vad-recording-device"
+		label="VAD Recording Device"
+		{items}
+		selected={selected ?? asDeviceIdentifier('')}
+		onSelectedChange={(value) =>
+			onSelectedChange(value ? asDeviceIdentifier(value) : null)}
+		placeholder="Select a device"
+	/>
+{/if}

--- a/apps/whispering/src/routes/(config)/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/shortcuts/global/+page.svelte
@@ -34,7 +34,7 @@
 				variant="outline"
 				size="sm"
 				onclick={() => {
-					settings.resetShortcuts('global');
+					settings.resetGlobalShortcuts();
 					rpc.notify.success.execute({
 						title: 'Shortcuts reset',
 						description: 'All global shortcuts have been reset to defaults.',

--- a/apps/whispering/src/routes/(config)/settings/shortcuts/local/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/shortcuts/local/+page.svelte
@@ -32,7 +32,7 @@
 			variant="outline"
 			size="sm"
 			onclick={() => {
-				settings.resetShortcuts('local');
+				settings.resetLocalShortcuts();
 				rpc.notify.success.execute({
 					title: 'Shortcuts reset',
 					description: 'All local shortcuts have been reset to defaults.',

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import CopyToClipboardButton from '$lib/components/copyable/CopyToClipboardButton.svelte';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
 	import {
@@ -7,92 +8,43 @@
 		LabeledTextarea,
 	} from '$lib/components/labeled/index.js';
 	import {
+		DeepgramApiKeyInput,
 		ElevenLabsApiKeyInput,
 		GroqApiKeyInput,
 		OpenAiApiKeyInput,
-		DeepgramApiKeyInput,
 	} from '$lib/components/settings';
-	import { Badge } from '@repo/ui/badge';
-	import { Button } from '@repo/ui/button';
-	import * as Card from '@repo/ui/card';
-	import { Checkbox } from '@repo/ui/checkbox';
-	import { Input } from '@repo/ui/input';
-	import { Separator } from '@repo/ui/separator';
-	import * as Alert from '@repo/ui/alert';
-	import { Link } from '@repo/ui/link';
-	import * as Collapsible from '@repo/ui/collapsible';
-	import * as Select from '@repo/ui/select';
+	import { CompressionBody } from '$lib/components/settings';
+	import WhisperModelSelector from '$lib/components/settings/WhisperModelSelector.svelte';
 	import { SUPPORTED_LANGUAGES_OPTIONS } from '$lib/constants/languages';
 	import {
+		DEEPGRAM_TRANSCRIPTION_MODELS,
 		ELEVENLABS_TRANSCRIPTION_MODELS,
 		GROQ_MODELS,
 		OPENAI_TRANSCRIPTION_MODELS,
 		TRANSCRIPTION_SERVICE_OPTIONS,
-		DEEPGRAM_TRANSCRIPTION_MODELS,
 	} from '$lib/constants/transcription';
 	import { settings } from '$lib/stores/settings.svelte';
 	import {
-		TriangleAlert,
-		InfoIcon,
 		CheckIcon,
+		InfoIcon,
 		RotateCcw,
+		TriangleAlert,
 	} from '@lucide/svelte';
-	import WhisperModelSelector from '$lib/components/settings/WhisperModelSelector.svelte';
-	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import * as Alert from '@repo/ui/alert';
+	import { Badge } from '@repo/ui/badge';
+	import { Button } from '@repo/ui/button';
+	import * as Card from '@repo/ui/card';
+	import { Checkbox } from '@repo/ui/checkbox';
+	import * as Collapsible from '@repo/ui/collapsible';
+	import { Input } from '@repo/ui/input';
+	import { Link } from '@repo/ui/link';
+	import * as Select from '@repo/ui/select';
+	import { Separator } from '@repo/ui/separator';
 	import {
-		isUsingWhisperCppWithBrowserMethod,
 		isUsingCpalMethodAtWrongSampleRate,
 		isUsingCpalMethodWithoutWhisperCpp,
+		isUsingWhisperCppWithBrowserMethod,
 	} from '../../../+layout/check-ffmpeg';
-	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
-	import { cn } from '@repo/ui/utils';
-
-	// Compression preset definitions (UI only - not stored in settings)
-	const COMPRESSION_PRESETS = {
-		recommended: {
-			label: 'Recommended',
-			icon: '🎯',
-			description: 'Best balance for speech',
-			options: '-c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10',
-			size: '~240KB/min',
-		},
-		tiny: {
-			label: 'Smallest',
-			icon: '🗜️',
-			description: 'Maximum compression',
-			options: '-c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
-			size: '~120KB/min',
-		},
-		compatible: {
-			label: 'Compatible',
-			icon: '✅',
-			description: 'Universal MP3',
-			options: '-c:a libmp3lame -b:a 32k -ar 16000 -ac 1 -q:a 9',
-			size: '~240KB/min',
-		},
-		quality: {
-			label: 'High Quality',
-			icon: '🎵',
-			description: 'Less compression',
-			options: '-c:a libmp3lame -b:a 64k -ar 16000 -ac 1 -q:a 2',
-			size: '~480KB/min',
-		},
-	} as const;
-
-	// Derive which preset is active based on current options
-	function isPresetActive(
-		presetKey: keyof typeof COMPRESSION_PRESETS,
-	): boolean {
-		return (
-			settings.value['transcription.compressionOptions'] ===
-			COMPRESSION_PRESETS[presetKey].options
-		);
-	}
-
-	// Set compression options directly
-	function setCompressionOptions(options: string) {
-		settings.updateKey('transcription.compressionOptions', options);
-	}
 </script>
 
 <svelte:head>
@@ -453,102 +405,7 @@
 	{/if}
 
 	<!-- Audio Compression Settings -->
-	<div class="space-y-2">
-		<div class="flex items-center space-x-2">
-			<Checkbox
-				id="compression-enabled"
-				checked={settings.value['transcription.compressionEnabled']}
-				onCheckedChange={(checked) => {
-					settings.updateKey('transcription.compressionEnabled', checked);
-				}}
-			/>
-			<label for="compression-enabled" class="text-sm font-medium">
-				Compress audio before transcription
-				{#if isUsingCpalMethodWithoutWhisperCpp()}
-					<Badge variant="secondary" class="ml-2">Recommended</Badge>
-				{/if}
-			</label>
-		</div>
-		{#if isUsingCpalMethodWithoutWhisperCpp()}
-			<p class="text-muted-foreground text-sm ml-6">
-				Recommended because you're using CPAL recording with cloud
-				transcription. Compression reduces file sizes for faster uploads and
-				lower API costs.
-			</p>
-		{/if}
-	</div>
-
-	{#if settings.value['transcription.compressionEnabled']}
-		<div class="space-y-4">
-			<!-- Preset Selection Badges -->
-			<div class="space-y-2">
-				<p class="text-sm font-medium">Compression Presets</p>
-				<div class="flex flex-wrap gap-2">
-					{#each Object.entries(COMPRESSION_PRESETS) as [presetKey, preset]}
-						<Badge
-							variant={isPresetActive(presetKey) ? 'default' : 'outline'}
-							class={cn(
-								'cursor-pointer transition-colors',
-								isPresetActive(presetKey)
-									? 'hover:bg-primary/90'
-									: 'hover:bg-accent hover:text-accent-foreground',
-							)}
-							onclick={() => setCompressionOptions(preset.options)}
-						>
-							<span class="mr-1">{preset.icon}</span>
-							{preset.label}
-							<span class="text-xs ml-1 opacity-75">{preset.size}</span>
-						</Badge>
-					{/each}
-				</div>
-				<p class="text-muted-foreground text-xs">
-					Choose a preset to automatically set FFmpeg compression options, or
-					customize below.
-				</p>
-			</div>
-
-			<!-- Custom Options Input -->
-			<LabeledInput
-				id="compression-options"
-				label="Compression Options"
-				value={settings.value['transcription.compressionOptions']}
-				oninput={({ currentTarget: { value } }) => {
-					settings.updateKey('transcription.compressionOptions', value);
-				}}
-				placeholder={FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
-				description="FFmpeg compression options. Changes here will be reflected in real-time during transcription."
-			>
-				{#snippet actionSlot()}
-					{#if settings.value['transcription.compressionOptions'] !== FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
-						<WhisperingButton
-							tooltipContent="Reset to default"
-							variant="ghost"
-							size="icon"
-							class="h-6 w-6"
-							onclick={() => {
-								settings.updateKey(
-									'transcription.compressionOptions',
-									FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
-								);
-							}}
-						>
-							<RotateCcw class="h-3 w-3" />
-						</WhisperingButton>
-					{/if}
-				{/snippet}
-			</LabeledInput>
-
-			<!-- Command Preview -->
-			<div class="text-sm text-muted-foreground">
-				<p class="font-medium mb-1">Command Preview:</p>
-				<code class="bg-muted rounded px-2 py-1 text-xs break-all">
-					ffmpeg -i input.wav {settings.value[
-						'transcription.compressionOptions'
-					]} output.opus
-				</code>
-			</div>
-		</div>
-	{/if}
+	<CompressionBody />
 
 	<LabeledSelect
 		id="output-language"

--- a/apps/whispering/src/routes/+layout/AppShell.svelte
+++ b/apps/whispering/src/routes/+layout/AppShell.svelte
@@ -23,9 +23,9 @@
 	} from './register-commands';
 	import { registerOnboarding } from './register-onboarding';
 	import { checkFfmpeg } from './check-ffmpeg';
-	import { 
+	import {
 		registerAccessibilityPermission,
-		registerMicrophonePermission 
+		registerMicrophonePermission,
 	} from './register-permissions';
 	import { syncIconWithRecorderState } from './syncIconWithRecorderState.svelte';
 
@@ -52,7 +52,7 @@
 			// await extension.notifyWhisperingTabReady(undefined);
 		}
 		registerOnboarding();
-		
+
 		// Register permission checkers separately
 		cleanupAccessibilityPermission = registerAccessibilityPermission();
 		cleanupMicrophonePermission = registerMicrophonePermission();
@@ -113,7 +113,7 @@
 	</span>
 </button>
 
-<div class="xxs:flex hidden flex-col items-center gap-2">
+<div class="hidden flex-col items-center gap-2 xxs:flex">
 	{@render children()}
 </div>
 

--- a/apps/whispering/src/routes/+layout/check-ffmpeg.ts
+++ b/apps/whispering/src/routes/+layout/check-ffmpeg.ts
@@ -20,7 +20,7 @@ function isUsingWhisperCpp(): boolean {
  * @returns true if using CPAL method for recording
  */
 function isUsingCpalMethod(): boolean {
-	return settings.value['recording.method'] === 'cpal';
+	return settings.value['recording.manual.method'] === 'cpal';
 }
 
 /**
@@ -28,7 +28,7 @@ function isUsingCpalMethod(): boolean {
  * @returns true if using navigator method for recording
  */
 function isUsingNavigatorMethod(): boolean {
-	return settings.value['recording.method'] === 'navigator';
+	return settings.value['recording.manual.method'] === 'navigator';
 }
 
 /**

--- a/apps/whispering/src/routes/+layout/check-ffmpeg.ts
+++ b/apps/whispering/src/routes/+layout/check-ffmpeg.ts
@@ -20,7 +20,7 @@ function isUsingWhisperCpp(): boolean {
  * @returns true if using CPAL method for recording
  */
 function isUsingCpalMethod(): boolean {
-	return settings.value['recording.manual.method'] === 'cpal';
+	return settings.value['recording.method'] === 'cpal';
 }
 
 /**
@@ -28,7 +28,7 @@ function isUsingCpalMethod(): boolean {
  * @returns true if using navigator method for recording
  */
 function isUsingNavigatorMethod(): boolean {
-	return settings.value['recording.manual.method'] === 'navigator';
+	return settings.value['recording.method'] === 'navigator';
 }
 
 /**

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -242,8 +242,8 @@
 						</WhisperingButton>
 					{:else}
 						<ManualDeviceSelector />
-						<TranscriptionSelector />
 						<CompressionSelector />
+						<TranscriptionSelector />
 						<TransformationSelector />
 					{/if}
 				</div>
@@ -268,8 +268,8 @@
 				<div class="flex justify-end items-center gap-1.5 mb-2">
 					{#if getVadStateQuery.data === 'IDLE'}
 						<VadDeviceSelector />
-						<TranscriptionSelector />
 						<CompressionSelector />
+						<TranscriptionSelector />
 						<TransformationSelector />
 					{/if}
 				</div>
@@ -294,8 +294,8 @@
 						class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
 					/>
 					<div class="flex items-center gap-1.5">
-						<TranscriptionSelector />
 						<CompressionSelector />
+						<TranscriptionSelector />
 						<TransformationSelector />
 					</div>
 				</div>

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -208,69 +208,75 @@
 			{/each}
 		</ToggleGroup.Root>
 
-		<div class="w-full grid grid-cols-[1fr_auto_1fr] items-end gap-2 pt-1">
-			<!-- Empty left column for centering -->
-			<div></div>
+		<div class="w-full flex justify-center pt-1">
 			{#if settings.value['recording.mode'] === 'manual'}
-				<!-- Center column: Recording button -->
-				<WhisperingButton
-					tooltipContent={getRecorderStateQuery.data === 'IDLE'
-						? 'Start recording'
-						: 'Stop recording'}
-					onclick={commandCallbacks.toggleManualRecording}
-					variant="ghost"
-					class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
-				>
-					<span
-						style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
-						class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+				<!-- Container with relative positioning for the button and absolute selectors -->
+				<div class="relative">
+					<!-- Recording button -->
+					<WhisperingButton
+						tooltipContent={getRecorderStateQuery.data === 'IDLE'
+							? 'Start recording'
+							: 'Stop recording'}
+						onclick={commandCallbacks.toggleManualRecording}
+						variant="ghost"
+						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
 					>
-						{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-					</span>
-				</WhisperingButton>
-				<!-- Right column: Selectors -->
-				<div class="flex justify-end items-center mb-2">
-					{#if getRecorderStateQuery.data === 'RECORDING'}
-						<WhisperingButton
-							tooltipContent="Cancel recording"
-							onclick={commandCallbacks.cancelManualRecording}
-							variant="ghost"
-							size="icon"
-							style="view-transition-name: cancel-icon;"
+						<span
+							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
 						>
-							🚫
-						</WhisperingButton>
+							{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+						</span>
+					</WhisperingButton>
+					<!-- Absolutely positioned selectors -->
+					{#if getRecorderStateQuery.data === 'RECORDING'}
+						<div class="absolute -right-12 bottom-4 flex items-center">
+							<WhisperingButton
+								tooltipContent="Cancel recording"
+								onclick={commandCallbacks.cancelManualRecording}
+								variant="ghost"
+								size="icon"
+								style="view-transition-name: cancel-icon;"
+							>
+								🚫
+							</WhisperingButton>
+						</div>
 					{:else}
-						<ManualDeviceSelector />
-						<CompressionSelector />
-						<TranscriptionSelector />
-						<TransformationSelector />
+						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+							<ManualDeviceSelector />
+							<CompressionSelector />
+							<TranscriptionSelector />
+							<TransformationSelector />
+						</div>
 					{/if}
 				</div>
 			{:else if settings.value['recording.mode'] === 'vad'}
-				<!-- Center column: Recording button -->
-				<WhisperingButton
-					tooltipContent={getVadStateQuery.data === 'IDLE'
-						? 'Start voice activated session'
-						: 'Stop voice activated session'}
-					onclick={commandCallbacks.toggleVadRecording}
-					variant="ghost"
-					class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
-				>
-					<span
-						style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
-						class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+				<!-- Container with relative positioning for the button and absolute selectors -->
+				<div class="relative">
+					<!-- Recording button -->
+					<WhisperingButton
+						tooltipContent={getVadStateQuery.data === 'IDLE'
+							? 'Start voice activated session'
+							: 'Stop voice activated session'}
+						onclick={commandCallbacks.toggleVadRecording}
+						variant="ghost"
+						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
 					>
-						{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-					</span>
-				</WhisperingButton>
-				<!-- Right column: Selectors -->
-				<div class="flex justify-end items-center mb-2">
+						<span
+							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+						>
+							{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+						</span>
+					</WhisperingButton>
+					<!-- Absolutely positioned selectors -->
 					{#if getVadStateQuery.data === 'IDLE'}
-						<VadDeviceSelector />
-						<CompressionSelector />
-						<TranscriptionSelector />
-						<TransformationSelector />
+						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+							<VadDeviceSelector />
+							<CompressionSelector />
+							<TranscriptionSelector />
+							<TransformationSelector />
+						</div>
 					{/if}
 				</div>
 			{:else if settings.value['recording.mode'] === 'upload'}

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 	import {
 		TranscriptionSelector,
 		TransformationSelector,
+		CompressionSelector,
 	} from '$lib/components/settings';
 	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
 	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
@@ -242,6 +243,7 @@
 					{:else}
 						<ManualDeviceSelector />
 						<TranscriptionSelector />
+						<CompressionSelector />
 						<TransformationSelector />
 					{/if}
 				</div>
@@ -267,6 +269,7 @@
 					{#if getVadStateQuery.data === 'IDLE'}
 						<VadDeviceSelector />
 						<TranscriptionSelector />
+						<CompressionSelector />
 						<TransformationSelector />
 					{/if}
 				</div>
@@ -292,6 +295,7 @@
 					/>
 					<div class="flex items-center gap-1.5">
 						<TranscriptionSelector />
+						<CompressionSelector />
 						<TransformationSelector />
 					</div>
 				</div>

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -229,7 +229,7 @@
 					</span>
 				</WhisperingButton>
 				<!-- Right column: Selectors -->
-				<div class="flex justify-end items-center gap-1.5 mb-2">
+				<div class="flex justify-end items-center mb-2">
 					{#if getRecorderStateQuery.data === 'RECORDING'}
 						<WhisperingButton
 							tooltipContent="Cancel recording"
@@ -265,7 +265,7 @@
 					</span>
 				</WhisperingButton>
 				<!-- Right column: Selectors -->
-				<div class="flex justify-end items-center gap-1.5 mb-2">
+				<div class="flex justify-end items-center mb-2">
 					{#if getVadStateQuery.data === 'IDLE'}
 						<VadDeviceSelector />
 						<CompressionSelector />

--- a/docs/articles/svelte-function-bindings-readonly-stores.md
+++ b/docs/articles/svelte-function-bindings-readonly-stores.md
@@ -59,18 +59,18 @@ Svelte 5 introduced [function bindings](https://svelte.dev/docs/svelte/bind#Func
 
 ```svelte
 <FfmpegCommandBuilder
-  bind:globalOptions={{
-    get: () => settings.value['recording.ffmpeg.globalOptions'],
-    set: (v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
-  }}
-  bind:inputOptions={{
-    get: () => settings.value['recording.ffmpeg.inputOptions'],
-    set: (v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
-  }}
-  bind:outputOptions={{
-    get: () => settings.value['recording.ffmpeg.outputOptions'],
-    set: (v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
-  }}
+  bind:globalOptions={
+    () => settings.value['recording.ffmpeg.globalOptions'],
+    (v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
+  }
+  bind:inputOptions={
+    () => settings.value['recording.ffmpeg.inputOptions'],
+    (v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
+  }
+  bind:outputOptions={
+    () => settings.value['recording.ffmpeg.outputOptions'],
+    (v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
+  }
 />
 ```
 


### PR DESCRIPTION
This refactors the device selection architecture from method-specific to mode-specific storage, significantly simplifying both the codebase and user experience. Previously, each recording method (CPAL, FFmpeg, Navigator) maintained its own device ID, creating unnecessary complexity and potential confusion for users switching between methods.

The new architecture uses mode-specific device storage: `recording.manual.selectedDeviceId` for manual recording and `recording.vad.selectedDeviceId` for voice-activated recording. This change makes the device selection more intuitive since users think in terms of recording modes (manual vs VAD) rather than technical implementation methods.

Additionally, this removes the compression UI components (`CompressionSelector`, `CompressionBody`) that were added in the previous compression feature. While the backend compression functionality remains fully intact, the UI complexity was streamlined based on the realization that the compression controls may have been overwhelming for the primary use case. Users can still access compression settings through the main settings page.

The device selector components have been consolidated and simplified, with `ManualDeviceSelector` and `VadDeviceSelector` now handling their respective modes more cleanly. This reduces the cognitive load on both developers and users while maintaining all the same functionality.