### PR TITLE
refactor: replace Button with Link for href-based components

### DIFF
--- a/apps/epicenter/src/components/ui/ToolCard.svelte
+++ b/apps/epicenter/src/components/ui/ToolCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as Card from '@repo/ui/card';
-  import { Button } from '@repo/ui/button';
+  import { Link } from '@repo/ui/link';
   
   type Props = {
     emoji: string;
@@ -23,8 +23,8 @@
     <Card.Description class="mb-4">
       {description}
     </Card.Description>
-    <Button href={href} variant="link" class="p-0 h-auto font-medium">
+    <Link href={href}>
       Try it now →
-    </Button>
+    </Link>
   </Card.Content>
 </Card.Root>

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -814,15 +814,13 @@ Adding a new transcription service involves four main steps:
    >
      {#snippet description()}
        <p class="text-muted-foreground text-sm">
-         You can find your YourService API key in your <Button
-           variant="link"
-           class="px-0.3 py-0.2 h-fit"
+         You can find your YourService API key in your <Link
            href="https://yourservice.com/api-keys"
            target="_blank"
            rel="noopener noreferrer"
          >
            YourService dashboard
-         </Button>.
+         </Link>.
        </p>
      {/snippet}
    </LabeledInput>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,15 +16,13 @@
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">
-			You can find your Anthropic API key in your <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			You can find your Anthropic API key in your <Link
 				href="https://console.anthropic.com/settings/keys"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				Anthropic console
-			</Button>.
+			</Link>.
 		</p>
 	{/snippet}
 </LabeledInput>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { LabeledInput } from '$lib/components/labeled/index.js';
-    import { Button } from '@repo/ui/button';
+    import { Link } from '@repo/ui/link';
     import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,23 +16,19 @@
 >
     {#snippet description()}
         <p class="text-muted-foreground text-sm">
-            You can find your API key in your <Button
-                variant="link"
-                class="px-0.3 py-0.2 h-fit"
+            You can find your API key in your <Link
                 href="https://console.deepgram.com/project"
                 target="_blank"
                 rel="noopener noreferrer"
             >
                 Deepgram Console
-            </Button>. Make sure you have <Button
-                variant="link"
-                class="px-0.3 py-0.2 h-fit"
+            </Link>. Make sure you have <Link
                 href="https://console.deepgram.com/billing"
                 target="_blank"
                 rel="noopener noreferrer"
             >
                 credits
-            </Button>
+            </Link>
             available.
         </p>
     {/snippet}

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,15 +16,13 @@
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">
-			You can find your ElevenLabs API key in your <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			You can find your ElevenLabs API key in your <Link
 				href="https://elevenlabs.io/app/settings/api-keys"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				ElevenLabs console
-			</Button>.
+			</Link>.
 		</p>
 	{/snippet}
 </LabeledInput>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,15 +16,13 @@
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">
-			You can find your Google API key in your <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			You can find your Google API key in your <Link
 				href="https://aistudio.google.com/app/apikey"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				Google AI Studio
-			</Button>.
+			</Link>.
 		</p>
 	{/snippet}
 </LabeledInput>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,15 +16,13 @@
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">
-			You can find your Groq API key in your <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			You can find your Groq API key in your <Link
 				href="https://console.groq.com/keys"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				Groq console
-			</Button>.
+			</Link>.
 		</p>
 	{/snippet}
 </LabeledInput>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
 </script>
 
@@ -16,23 +16,19 @@
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">
-			You can find your API key in your <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			You can find your API key in your <Link
 				href="https://platform.openai.com/api-keys"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				account settings
-			</Button>. Make sure <Button
-				variant="link"
-				class="px-0.3 py-0.2 h-fit"
+			</Link>. Make sure <Link
 				href="https://platform.openai.com/settings/organization/billing/overview"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				billing
-			</Button>
+			</Link>
 			is enabled.
 		</p>
 	{/snippet}

--- a/apps/whispering/src/routes/(config)/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(config)/settings/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
 	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
 	import { Separator } from '@repo/ui/separator';
 	import { rpc } from '$lib/query';
 	import { RotateCcw } from '@lucide/svelte';
@@ -49,16 +50,13 @@
 					{#if v.isOutdated}
 						{@const { latestVersion, currentVersion, latestReleaseUrl } = v}
 						Customize your experience for Whispering {currentVersion} (latest
-						<Button
-							class="px-0"
-							variant="link"
-							size="inline"
+						<Link
 							href={latestReleaseUrl}
 							target="_blank"
 							rel="noopener noreferrer"
 						>
 							{latestVersion}
-						</Button>).
+						</Link>).
 					{:else}
 						{@const { version } = v}
 						Customize your experience for Whispering {version}.

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -90,15 +90,13 @@
 			renderOption={renderModelOption}
 		>
 			{#snippet description()}
-				You can find more details about the models in the <Button
-					variant="link"
-					class="px-0.3 py-0.2 h-fit"
+				You can find more details about the models in the <Link
 					href="https://platform.openai.com/docs/guides/speech-to-text"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
 					OpenAI docs
-				</Button>.
+				</Link>.
 			{/snippet}
 		</LabeledSelect>
 		<OpenAiApiKeyInput />
@@ -118,15 +116,13 @@
 			renderOption={renderModelOption}
 		>
 			{#snippet description()}
-				You can find more details about the models in the <Button
-					variant="link"
-					class="px-0.3 py-0.2 h-fit"
+				You can find more details about the models in the <Link
 					href="https://console.groq.com/docs/speech-to-text"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
 					Groq docs
-				</Button>.
+				</Link>.
 			{/snippet}
 		</LabeledSelect>
 		<GroqApiKeyInput />
@@ -162,15 +158,13 @@
 			renderOption={renderModelOption}
 		>
 			{#snippet description()}
-				You can find more details about the models in the <Button
-					variant="link"
-					class="px-0.3 py-0.2 h-fit"
+				You can find more details about the models in the <Link
 					href="https://elevenlabs.io/docs/capabilities/speech-to-text"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
 					ElevenLabs docs
-				</Button>.
+				</Link>.
 			{/snippet}
 		</LabeledSelect>
 		<ElevenLabsApiKeyInput />
@@ -212,16 +206,13 @@
 							</p>
 							<ul class="ml-6 mt-2 space-y-2 text-sm text-muted-foreground">
 								<li class="list-disc">
-									Download the necessary docker compose files from the <Button
-										variant="link"
-										size="sm"
-										class="px-0 h-auto underline"
+									Download the necessary docker compose files from the <Link
 										href="https://speaches.ai/installation/"
 										target="_blank"
 										rel="noopener noreferrer"
 									>
 										installation guide
-									</Button>
+									</Link>
 								</li>
 								<li class="list-disc">
 									Choose CUDA, CUDA with CDI, or CPU variant depending on your
@@ -248,16 +239,13 @@
 							</p>
 							<ul class="ml-6 mt-2 space-y-2 text-sm text-muted-foreground">
 								<li class="list-disc">
-									View available models in the <Button
-										variant="link"
-										size="sm"
-										class="px-0 h-auto underline"
+									View available models in the <Link
 										href="https://speaches.ai/usage/speech-to-text/"
 										target="_blank"
 										rel="noopener noreferrer"
 									>
 										speech-to-text guide
-									</Button>
+									</Link>
 								</li>
 								<li class="list-disc">
 									Run the following command to download a model:

--- a/apps/whispering/src/routes/+page.svelte
+++ b/apps/whispering/src/routes/+page.svelte
@@ -361,7 +361,6 @@
 					tooltipContent="Go to local shortcut in settings"
 					href="/settings/shortcuts/local"
 					variant="link"
-					size="inline"
 				>
 					<kbd
 						class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
@@ -378,7 +377,6 @@
 						tooltipContent="Go to global shortcut in settings"
 						href="/settings/shortcuts/global"
 						variant="link"
-						size="inline"
 					>
 						<kbd
 							class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
@@ -398,7 +396,6 @@
 						target="_blank"
 						rel="noopener noreferrer"
 						variant="link"
-						size="inline"
 					>
 						Get the native desktop app
 					</WhisperingButton>

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -17,7 +17,6 @@
 			size: {
 				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
 				icon: 'size-9',
-				inline: 'h-fit px-0.5 py-0',
 				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
 				sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
 			},
@@ -28,7 +27,7 @@
 					'bg-destructive shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white',
 				ghost:
 					'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-				link: 'text-primary underline-offset-4 hover:underline',
+				link: 'text-primary underline-offset-4 hover:underline px-0.3 py-0.2 h-fit',
 				outline:
 					'bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border',
 				secondary:


### PR DESCRIPTION
This refactor replaces Button components with the new Link component when used with href attributes, providing better semantic markup and cleaner styling for link-like interactions.

The changes consolidate all href-based buttons to use the dedicated Link component, which provides appropriate link styling without needing button-specific variants. This includes updating API key input descriptions, documentation links, and shortcut buttons throughout the application. The Button component's inline size variant has been removed since it was only used for link styling, with the styling now integrated directly into the Link component.

This improves semantic correctness by using actual links for navigation rather than buttons styled as links, while maintaining the same visual appearance and user experience.