### PR TITLE
fix(whisper): disable GPU acceleration in CI/CD builds

### DIFF
--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -68,12 +68,14 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-# Windows: CUDA for NVIDIA GPUs, Vulkan for AMD/Intel GPUs
-whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan"] }
+# Windows: GPU acceleration disabled in CI/CD builds
+# Uncomment the following line to enable GPU support when building locally:
+# whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan"] }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-# Linux: CUDA for NVIDIA, Vulkan for AMD/Intel, HipBLAS for AMD ROCm
-whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan", "hipblas"] }
+# Linux: GPU acceleration disabled in CI/CD builds
+# Uncomment the following line to enable GPU support when building locally:
+# whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan", "hipblas"] }
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.


### PR DESCRIPTION
This PR disables GPU acceleration features (CUDA, Vulkan, HipBLAS) in CI/CD builds to fix build failures. The CI runners don't have the necessary GPU SDKs and toolchains installed, causing builds to fail with linking errors.

## The Problem

Our CI/CD pipeline has been failing on Windows and Linux with errors like:
```
error: failed to run custom build command for whisper-rs-sys v0.14.0
thread 'main' panicked at build.rs:58:69:
called Result::unwrap() on an Err value: NotPresent
```

This happens because:
1. The `whisper-rs` crate tries to link against CUDA libraries (`cublas`, `cudart`, `cublasLt`, `cuda`) when the `cuda` feature is enabled
2. GitHub Actions runners don't have CUDA, Vulkan SDK, or AMD ROCm installed
3. The build script panics when it can't find `CUDA_PATH` on Windows

## The Solution

This PR removes the platform-specific GPU features from the default builds:
- **Windows**: Removed `cuda` and `vulkan` features
- **Linux**: Removed `cuda`, `vulkan`, and `hipblas` features  
- **macOS**: Kept `coreml` as it's built into macOS (no SDK needed)

## For Users Who Want GPU Acceleration

Users can still build with GPU acceleration locally by uncommenting the platform-specific lines in `Cargo.toml`:

```toml
# Windows: Uncomment for GPU support
# whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan"] }

# Linux: Uncomment for GPU support  
# whisper-rs = { version = "0.15.0", features = ["cuda", "vulkan", "hipblas"] }
```

This requires having the appropriate SDKs installed:
- **CUDA**: NVIDIA CUDA Toolkit
- **Vulkan**: Vulkan SDK
- **HipBLAS**: AMD ROCm

## Related Issues

This addresses GPU-related concerns from:
- #706 - Users wondering if GPU is working (it wasn't in releases)
- #663 - Request for local GPU transcription support
- #675 - Local transcription performance issues

## Impact

- ✅ CI/CD builds will succeed again
- ✅ Releases will be CPU-only but stable
- ✅ Users can still build with GPU locally if needed
- ✅ No functionality loss; whisper-rs falls back to CPU gracefully

The trade-off is that our official releases won't have GPU acceleration, but given the complexity of bundling GPU runtimes and the variety of GPU configurations, CPU-only releases are more reliable for the majority of users.