### PR TITLE
chore(whispering): remove deprecated groq model

### DIFF
--- a/apps/whispering/src/lib/services/transcription/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/groq.ts
@@ -18,12 +18,6 @@ export const GROQ_MODELS = [
 			'Fast multilingual model with good accuracy (12% WER). Best price-to-performance ratio for multilingual applications.',
 		cost: '$0.04/hour',
 	},
-	{
-		name: 'distil-whisper-large-v3-en',
-		description:
-			'Fastest and most cost-effective model, but English-only. Recommended for English transcription where speed and cost are priorities.',
-		cost: '$0.02/hour',
-	},
 ] as const;
 
 export type GroqModel = (typeof GROQ_MODELS)[number];
@@ -55,7 +49,10 @@ export function createGroqTranscriptionService() {
 				});
 			}
 
-			if (!options.apiKey.startsWith('gsk_') && !options.apiKey.startsWith('xai-')) {
+			if (
+				!options.apiKey.startsWith('gsk_') &&
+				!options.apiKey.startsWith('xai-')
+			) {
 				return WhisperingErr({
 					title: '🔑 Invalid API Key Format',
 					description:


### PR DESCRIPTION
Remove model "distil-whisper-large-v3-en" from groq due to deprecation
When I attempted to use it in a transcription, this error was shown:
`400 {"error":{"message":"The model `distil-whisper-large-v3-en` has been decommissioned and is no longer supported. Please refer to https://console.groq.com/docs/deprecations for a recommendation on which model to use instead.","type":"invalid_request_error","code":"model_decommissioned"}}`

Changes:
- Removed entry: `{
		name: 'distil-whisper-large-v3-en',
		description:
			'Fastest and most cost-effective model, but English-only. Recommended for English transcription where speed and cost are priorities.',
		cost: '$0.02/hour',
	},` from `GROQ_MODELS` array in `/epicenter/apps/whispering/src/lib/services/transcription/groq.ts`